### PR TITLE
fix: security hardening (P0-P3)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,7 +38,7 @@ Omniscribe implements the following security measures:
 - `nodeIntegration: false` and `contextIsolation: true` in Electron
 - Content Security Policy (CSP) for the renderer process
 - CORS restricted to localhost origins
-- Input validation and shell escaping for CLI commands
+- Safe argument passing for CLI commands (execFile with argument arrays)
 - External links opened in system browser (not in-app)
 
 ## Thank You

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -9,6 +9,7 @@ import { logger, getLogPath } from './logger';
 import { initializeAutoUpdater } from './updater';
 import { corsOriginCallback } from '../modules/shared/cors.config';
 import { NestLoggerAdapter } from '../modules/shared/nest-logger';
+import { LOCALHOST } from '@omniscribe/shared';
 
 export let mainWindow: BrowserWindow | null = null;
 let nestApp: INestApplication | null = null;
@@ -32,7 +33,7 @@ async function bootstrapNestApp(): Promise<void> {
     });
 
     logger.info('Starting to listen on port 3001...');
-    await nestApp.listen(3001);
+    await nestApp.listen(3001, LOCALHOST);
     logger.info('NestJS server running on port 3001');
     logger.info('Log file location:', getLogPath());
   } catch (error) {

--- a/apps/desktop/src/modules/git/git-base.service.spec.ts
+++ b/apps/desktop/src/modules/git/git-base.service.spec.ts
@@ -1,18 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { GitBaseService } from './git-base.service';
 
-// The promisified exec mock function.
+// The promisified execFile mock function.
 // We create this inside the util mock factory (which gets hoisted),
-// then expose it via the module's __mockExec for test access.
-let mockExec: jest.Mock;
+// then expose it via the module's __mockExecFile for test access.
+let mockExecFile: jest.Mock;
 
 // Mock util.promisify to return a jest.fn() we control.
-// This must be done because GitBaseService calls `const execAsync = promisify(exec)`
+// This must be done because GitBaseService calls `const execFileAsync = promisify(execFile)`
 // at module scope — we intercept promisify to return our mock.
 jest.mock('util', () => {
   const fn = jest.fn();
   // Store reference so tests can access it
-  (global as Record<string, unknown>).__mockExec = fn;
+  (global as Record<string, unknown>).__mockExecFile = fn;
   return {
     promisify: () => fn,
   };
@@ -20,7 +20,7 @@ jest.mock('util', () => {
 
 // Also mock child_process so the import doesn't fail
 jest.mock('child_process', () => ({
-  exec: jest.fn(),
+  execFile: jest.fn(),
   ExecException: Error,
 }));
 
@@ -28,19 +28,19 @@ describe('GitBaseService', () => {
   let service: GitBaseService;
 
   beforeEach(async () => {
-    mockExec = (global as Record<string, unknown>).__mockExec as jest.Mock;
+    mockExecFile = (global as Record<string, unknown>).__mockExecFile as jest.Mock;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [GitBaseService],
     }).compile();
 
     service = module.get<GitBaseService>(GitBaseService);
-    mockExec.mockReset();
+    mockExecFile.mockReset();
   });
 
   describe('execGit', () => {
     it('should execute a git command and return stdout/stderr', async () => {
-      mockExec.mockResolvedValue({
+      mockExecFile.mockResolvedValue({
         stdout: 'abc123\n',
         stderr: '',
       });
@@ -48,8 +48,9 @@ describe('GitBaseService', () => {
       const result = await service.execGit('/repo', ['rev-parse', 'HEAD']);
 
       expect(result).toEqual({ stdout: 'abc123\n', stderr: '' });
-      expect(mockExec).toHaveBeenCalledWith(
-        'git rev-parse HEAD',
+      expect(mockExecFile).toHaveBeenCalledWith(
+        'git',
+        ['rev-parse', 'HEAD'],
         expect.objectContaining({
           cwd: '/repo',
         })
@@ -57,11 +58,11 @@ describe('GitBaseService', () => {
     });
 
     it('should pass GIT_ENV variables to prevent interactive prompts', async () => {
-      mockExec.mockResolvedValue({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
 
       await service.execGit('/repo', ['status']);
 
-      const callOpts = mockExec.mock.calls[0][1];
+      const callOpts = mockExecFile.mock.calls[0][2];
       expect(callOpts.env).toEqual(
         expect.objectContaining({
           GIT_TERMINAL_PROMPT: '0',
@@ -71,20 +72,20 @@ describe('GitBaseService', () => {
     });
 
     it('should use the specified timeout', async () => {
-      mockExec.mockResolvedValue({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
 
       await service.execGit('/repo', ['status'], 5000);
 
-      const callOpts = mockExec.mock.calls[0][1];
+      const callOpts = mockExecFile.mock.calls[0][2];
       expect(callOpts.timeout).toBe(5000);
     });
 
     it('should set maxBuffer to 10MB', async () => {
-      mockExec.mockResolvedValue({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
 
       await service.execGit('/repo', ['log']);
 
-      const callOpts = mockExec.mock.calls[0][1];
+      const callOpts = mockExecFile.mock.calls[0][2];
       expect(callOpts.maxBuffer).toBe(10 * 1024 * 1024);
     });
 
@@ -95,7 +96,7 @@ describe('GitBaseService', () => {
         stderr?: string;
       };
       error.killed = true;
-      mockExec.mockRejectedValue(error);
+      mockExecFile.mockRejectedValue(error);
 
       await expect(service.execGit('/repo', ['fetch'], 1000)).rejects.toThrow(
         'Git command timed out after 1000ms'
@@ -111,7 +112,7 @@ describe('GitBaseService', () => {
       error.stdout = 'partial output';
       error.stderr = 'error message';
       error.killed = false;
-      mockExec.mockRejectedValue(error);
+      mockExecFile.mockRejectedValue(error);
 
       const result = await service.execGit('/repo', ['diff']);
 
@@ -123,19 +124,23 @@ describe('GitBaseService', () => {
 
     it('should throw when exec fails without stdout/stderr', async () => {
       const error = new Error('ENOENT: command not found');
-      mockExec.mockRejectedValue(error);
+      mockExecFile.mockRejectedValue(error);
 
       await expect(service.execGit('/repo', ['status'])).rejects.toThrow(
         'Git command failed: ENOENT: command not found'
       );
     });
 
-    it('should join args into a single git command string', async () => {
-      mockExec.mockResolvedValue({ stdout: '', stderr: '' });
+    it('should pass args as an array to execFile', async () => {
+      mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
 
       await service.execGit('/repo', ['branch', '-a', '--list', 'feature/*']);
 
-      expect(mockExec).toHaveBeenCalledWith('git branch -a --list feature/*', expect.anything());
+      expect(mockExecFile).toHaveBeenCalledWith(
+        'git',
+        ['branch', '-a', '--list', 'feature/*'],
+        expect.anything()
+      );
     });
   });
 });

--- a/apps/desktop/src/modules/git/git-base.service.ts
+++ b/apps/desktop/src/modules/git/git-base.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { exec, ExecException } from 'child_process';
+import { execFile, ExecException } from 'child_process';
 import { promisify } from 'util';
 import { GIT_TIMEOUT_MS, createLogger } from '@omniscribe/shared';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /** Git environment variables to prevent interactive prompts */
 export const GIT_ENV: Record<string, string> = {
@@ -28,11 +28,11 @@ export class GitBaseService {
     args: string[],
     timeoutMs: number = GIT_TIMEOUT_MS
   ): Promise<ExecResult> {
-    const command = `git ${args.join(' ')}`;
-    this.logger.debug(`execGit: ${command} (cwd: ${repoPath})`);
+    const commandStr = `git ${args.join(' ')}`;
+    this.logger.debug(`execGit: ${commandStr} (cwd: ${repoPath})`);
 
     try {
-      const result = await execAsync(command, {
+      const result = await execFileAsync('git', args, {
         cwd: repoPath,
         timeout: timeoutMs,
         env: {
@@ -51,8 +51,8 @@ export class GitBaseService {
 
       // Check for timeout
       if (execError.killed) {
-        this.logger.warn(`Git command timed out after ${timeoutMs}ms: ${command}`);
-        throw new Error(`Git command timed out after ${timeoutMs}ms: ${command}`);
+        this.logger.warn(`Git command timed out after ${timeoutMs}ms: ${commandStr}`);
+        throw new Error(`Git command timed out after ${timeoutMs}ms: ${commandStr}`);
       }
 
       // Return stdout/stderr even on non-zero exit codes (some git commands use this)

--- a/apps/mcp-server/esbuild.config.mjs
+++ b/apps/mcp-server/esbuild.config.mjs
@@ -1,4 +1,7 @@
 import * as esbuild from 'esbuild';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 // Bundle the MCP server into a single file for distribution
 await esbuild.build({
@@ -10,6 +13,9 @@ await esbuild.build({
   outfile: 'dist/index.js',
   sourcemap: false,
   minify: true,
+  define: {
+    __VERSION__: JSON.stringify(pkg.version),
+  },
   // Add banner for ESM compatibility and shebang
   banner: {
     js: '#!/usr/bin/env node',

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -9,7 +9,7 @@ import { createHttpClient } from './http/index.js';
 import { registerTools } from './tools/index.js';
 import { logger } from './utils/index.js';
 
-const VERSION = '0.1.0';
+declare const __VERSION__: string;
 
 /**
  * Create and configure the MCP server
@@ -23,7 +23,7 @@ export function createServer(): {
 
   const server = new McpServer({
     name: 'omniscribe',
-    version: VERSION,
+    version: __VERSION__,
   });
 
   // Register all tools
@@ -40,7 +40,7 @@ export function createServer(): {
  * Start the MCP server
  */
 export async function startServer(): Promise<void> {
-  logger.info(`Starting Omniscribe MCP Server v${VERSION}`);
+  logger.info(`Starting Omniscribe MCP Server v${__VERSION__}`);
 
   const { server, config } = createServer();
 


### PR DESCRIPTION
## Summary
- **[P0] Fix shell injection** — Replace `exec()` with `execFile()` in `git-base.service` and `github.service` to prevent shell metacharacter injection via argument concatenation
- **[P1] Bind backend to localhost** — `nestApp.listen(3001, '127.0.0.1')` instead of defaulting to `0.0.0.0`, preventing LAN exposure
- **[P2] Fix socket connection hang** — Replace `setInterval` polling (no timeout/rejection) with a pending callers queue and 30s timeout
- **[P3] Fix MCP server version drift** — Inject version from `package.json` at esbuild build time instead of hardcoded `'0.1.0'`
- **[P3] Update SECURITY.md** — Reflect `execFile` with argument arrays instead of "shell escaping"

## Files changed (9)
| File | Change |
|------|--------|
| `apps/desktop/src/modules/git/git-base.service.ts` | `exec` → `execFile` |
| `apps/desktop/src/modules/git/git-base.service.spec.ts` | Updated mocks for `execFile` (args array) |
| `apps/desktop/src/modules/git/github.service.ts` | `exec` → `execFile` in execGh, findCli, getVersion, checkAuth |
| `apps/desktop/src/modules/git/github.service.spec.ts` | Updated mocks for `execFile` (args array) |
| `apps/desktop/src/main/index.ts` | Bind to `LOCALHOST` (`127.0.0.1`) |
| `apps/web/src/lib/socket.ts` | Pending callers queue with 30s timeout |
| `apps/mcp-server/esbuild.config.mjs` | Read version from package.json, inject via `define` |
| `apps/mcp-server/src/server.ts` | Use `__VERSION__` instead of hardcoded string |
| `SECURITY.md` | Updated security measures description |

## Test plan
- [x] `pnpm test` — 848 tests pass (32 suites)
- [x] `pnpm build` — builds successfully (MCP version injected)
- [x] `pnpm lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved network security by binding the server to localhost only.
  * Updated CLI command execution to use safer argument handling patterns.

* **Documentation**
  * Updated security guidelines for command invocation.

* **Bug Fixes**
  * Added connection timeout mechanism (30 seconds) for improved socket connection reliability.

* **Improvements**
  * Dynamic version information now sourced from build metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->