### PR TITLE
feat: version bump script and CI auto-sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,12 @@ jobs:
       - name: Extract version from tag
         id: version
         shell: bash
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${TAG_NAME}"
           VERSION="${VERSION#v}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Extracted version: ${VERSION}"
 
       - name: Update package.json versions
@@ -156,13 +158,20 @@ jobs:
           ref: master
           fetch-depth: 1
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
       - name: Extract version from tag
         id: version
         shell: bash
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${TAG_NAME}"
           VERSION="${VERSION#v}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Bump package versions
         shell: bash
@@ -174,6 +183,6 @@ jobs:
           git diff --quiet && exit 0
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json apps/desktop/package.json apps/web/package.json apps/mcp-server/package.json packages/shared/package.json
+          git add -A
           git commit -m "chore: sync package versions to ${{ steps.version.outputs.version }} [skip ci]"
           git push origin master


### PR DESCRIPTION
## Summary
- Add `scripts/bump-version.sh` for local version bumping — supports `patch`, `minor`, `major`, or explicit version (e.g. `0.2.0`)
- Replace inline node version-bump logic in `release.yml` build job with the shared script
- Add `version-sync` job that runs after successful release upload to commit bumped `package.json` versions back to `master`

## How it works

**Local usage:**
```bash
./scripts/bump-version.sh patch   # 0.1.4 → 0.1.5
./scripts/bump-version.sh minor   # 0.1.4 → 0.2.0
./scripts/bump-version.sh 1.0.0   # explicit version
```

**CI flow:**
1. `build` job — uses `bump-version.sh` to set versions from release tag (existing behavior, now using shared script)
2. `upload` job — uploads artifacts to GitHub Release (unchanged)
3. **`version-sync` job (new)** — checks out `master`, runs `bump-version.sh`, commits + pushes if versions differ

The `[skip ci]` in the commit message prevents infinite workflow loops.

Closes #25

## Test plan
- [x] Script prints usage when called with no args
- [x] Script validates semver format
- [x] Release workflow uses shared script in build job
- [x] `version-sync` job only commits when there's a diff (`git diff --quiet && exit 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored the release workflow to use a centralized version management script, improving consistency and maintainability of package versioning across the monorepo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->