### PR TITLE
refactor: consolidate buttons to shadcn Button component

### DIFF
--- a/apps/web/src/components/settings/sections/InstallCommandDisplay.tsx
+++ b/apps/web/src/components/settings/sections/InstallCommandDisplay.tsx
@@ -1,6 +1,7 @@
 import { Copy, Check, Play, TriangleAlert } from 'lucide-react';
 import { clsx } from 'clsx';
 import type { ClaudeInstallCommand } from '@omniscribe/shared';
+import { Button } from '@/components/ui/button';
 
 interface InstallCommandDisplayProps {
   installCommand: ClaudeInstallCommand;
@@ -22,14 +23,11 @@ export function InstallCommandDisplay({
       <div className="flex items-center justify-between mb-2">
         <span className="text-sm font-medium text-foreground">{installCommand.description}</span>
         <div className="flex items-center gap-2">
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={onCopy}
-            className={clsx(
-              'flex items-center gap-1 px-2 py-1 rounded text-xs',
-              'hover:bg-muted transition-colors',
-              copiedCommand ? 'text-status-success' : 'text-muted-foreground hover:text-foreground'
-            )}
+            className={clsx('text-xs', copiedCommand ? 'text-status-success' : '')}
           >
             {copiedCommand ? (
               <>
@@ -42,7 +40,7 @@ export function InstallCommandDisplay({
                 Copy
               </>
             )}
-          </button>
+          </Button>
         </div>
       </div>
       <div className="p-3 rounded-lg bg-muted font-mono text-xs text-foreground overflow-x-auto">
@@ -66,18 +64,10 @@ export function InstallCommandDisplay({
         <p className="text-xs text-muted-foreground">
           Click the button to open a terminal with this command.
         </p>
-        <button
-          type="button"
-          onClick={onRunInTerminal}
-          className={clsx(
-            'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium',
-            'bg-primary text-primary-foreground',
-            'hover:bg-primary/90 transition-colors'
-          )}
-        >
+        <Button variant="default" size="sm" onClick={onRunInTerminal} className="text-xs">
           <Play className="w-3.5 h-3.5" />
           Run in Terminal
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/src/components/shared/IdleLandingView.tsx
+++ b/apps/web/src/components/shared/IdleLandingView.tsx
@@ -3,6 +3,7 @@ import { twMerge } from 'tailwind-merge';
 import { BrainCircuit, Plus } from 'lucide-react';
 import { useMemo } from 'react';
 import { getGreeting } from '@/lib/date-utils';
+import { Button } from '@/components/ui/button';
 
 interface IdleLandingViewProps {
   onAddSession: () => void;
@@ -72,26 +73,12 @@ export function IdleLandingView({
         </p>
 
         {/* Add session button - opens modal as primary action */}
-        <button
-          onClick={handlePrimaryCTA}
-          className={clsx(
-            'w-16 h-16 rounded-full',
-            'bg-gradient-to-br from-primary to-brand-600',
-            'flex items-center justify-center',
-            'shadow-lg shadow-primary/25',
-            'hover:shadow-xl hover:shadow-primary/30',
-            'hover:scale-105 active:scale-95',
-            'transition-all duration-200',
-            'group'
-          )}
-          aria-label="Set up sessions"
-        >
+        <Button onClick={handlePrimaryCTA} type="button" size={'icon'} aria-label="Set up sessions">
           <Plus
-            size={32}
             className="text-white group-hover:rotate-90 transition-transform duration-200"
             strokeWidth={2}
           />
-        </button>
+        </Button>
 
         {/* Keyboard shortcut hint */}
         <p className="mt-6 text-xs text-muted-foreground">

--- a/apps/web/src/components/shared/TopBar.tsx
+++ b/apps/web/src/components/shared/TopBar.tsx
@@ -5,6 +5,7 @@ import { StatusLegend, StatusCounts } from './StatusLegend';
 import { StatusDot, SessionStatus } from './StatusLegend';
 import { UsagePopover } from '@/components/shared/UsagePopover';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import { Button } from '@/components/ui/button';
 import { useSettingsStore } from '@/stores';
 
 const MAX_SESSIONS = 12;
@@ -106,21 +107,18 @@ export function TopBar({
             <span className="text-sm truncate max-w-32">{tab.label}</span>
             <Tooltip>
               <TooltipTrigger asChild>
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="icon"
                   onClick={e => {
                     e.stopPropagation();
                     onCloseTab(tab.id);
                   }}
-                  className={clsx(
-                    'p-0.5 rounded opacity-0 group-hover:opacity-100',
-                    'hover:bg-border transition-all',
-                    'text-muted-foreground hover:text-foreground'
-                  )}
+                  className="p-0.5 h-auto w-auto opacity-0 group-hover:opacity-100"
                   aria-label={`Close ${tab.label}`}
                 >
                   <X size={14} />
-                </button>
+                </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom">Close tab</TooltipContent>
             </Tooltip>
@@ -129,19 +127,16 @@ export function TopBar({
 
         <Tooltip>
           <TooltipTrigger asChild>
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="icon"
               data-testid="new-tab-button"
               onClick={onNewTab}
-              className={clsx(
-                'no-drag flex items-center justify-center px-3 h-full',
-                'text-muted-foreground hover:text-foreground',
-                'hover:bg-card/50 transition-colors'
-              )}
+              className="no-drag px-3 h-full"
               aria-label="New tab"
             >
               <Plus size={16} />
-            </button>
+            </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">New tab</TooltipContent>
         </Tooltip>
@@ -175,18 +170,15 @@ export function TopBar({
         {/* Settings */}
         <Tooltip>
           <TooltipTrigger asChild>
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={() => openSettings()}
-              className={clsx(
-                'no-drag w-7 h-7 flex items-center justify-center rounded',
-                'text-muted-foreground hover:text-foreground',
-                'hover:bg-card transition-colors'
-              )}
+              className="no-drag w-7 h-7"
               aria-label="Settings"
             >
               <Settings size={15} />
-            </button>
+            </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">Settings</TooltipContent>
         </Tooltip>
@@ -195,19 +187,16 @@ export function TopBar({
         {canAddMore && onOpenLaunchModal && (
           <Tooltip>
             <TooltipTrigger asChild>
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="icon"
                 data-testid="setup-sessions-button"
                 onClick={onOpenLaunchModal}
-                className={clsx(
-                  'no-drag w-7 h-7 flex items-center justify-center rounded',
-                  'text-muted-foreground hover:text-foreground',
-                  'hover:bg-card transition-colors'
-                )}
+                className="no-drag w-7 h-7"
                 aria-label="Set up sessions"
               >
                 <LayoutGrid size={15} />
-              </button>
+              </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
               Set up sessions
@@ -220,19 +209,16 @@ export function TopBar({
         {canAddMore && onAddSlot && preLaunchSlotCount > 0 && (
           <Tooltip>
             <TooltipTrigger asChild>
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="icon"
                 data-testid="add-session-button"
                 onClick={onAddSlot}
-                className={clsx(
-                  'no-drag w-7 h-7 flex items-center justify-center rounded',
-                  'text-muted-foreground hover:text-foreground',
-                  'hover:bg-card transition-colors'
-                )}
+                className="no-drag w-7 h-7"
                 aria-label="Add session"
               >
                 <Plus size={15} />
-              </button>
+              </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
               Add session
@@ -245,19 +231,16 @@ export function TopBar({
         {hasActiveSessions && (
           <Tooltip>
             <TooltipTrigger asChild>
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="icon"
                 data-testid="stop-all-button"
                 onClick={onStopAll}
-                className={clsx(
-                  'no-drag w-7 h-7 flex items-center justify-center rounded',
-                  'text-destructive hover:text-destructive',
-                  'hover:bg-destructive/10 transition-colors'
-                )}
+                className="no-drag w-7 h-7 text-destructive hover:text-destructive hover:bg-destructive/10"
                 aria-label="Stop all sessions"
               >
                 <Square size={14} fill="currentColor" />
-              </button>
+              </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
               Stop all sessions
@@ -271,22 +254,20 @@ export function TopBar({
         {/* Launch */}
         <Tooltip>
           <TooltipTrigger asChild>
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="icon"
               data-testid="launch-button"
               onClick={onLaunch}
               disabled={!canLaunch || isLaunching}
               className={clsx(
-                'no-drag w-7 h-7 flex items-center justify-center rounded',
-                'transition-colors',
-                canLaunch && !isLaunching
-                  ? 'text-primary hover:bg-primary/10'
-                  : 'text-muted-foreground cursor-not-allowed opacity-60'
+                'no-drag w-7 h-7',
+                canLaunch && !isLaunching && 'text-primary hover:bg-primary/10'
               )}
               aria-label="Launch all sessions"
             >
               <Play size={15} fill="currentColor" />
-            </button>
+            </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">
             {isLaunching ? 'Launching...' : 'Launch all sessions'}
@@ -304,52 +285,43 @@ export function TopBar({
           <div className="flex items-center gap-1">
             <Tooltip>
               <TooltipTrigger asChild>
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="icon"
                   onClick={() => window.electronAPI?.window.minimize()}
-                  className={clsx(
-                    'w-7 h-7 flex items-center justify-center rounded',
-                    'hover:bg-card transition-colors',
-                    'text-muted-foreground hover:text-foreground'
-                  )}
+                  className="w-7 h-7"
                   aria-label="Minimize"
                 >
                   <Minus size={14} />
-                </button>
+                </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom">Minimize</TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="icon"
                   onClick={() => window.electronAPI?.window.maximize()}
-                  className={clsx(
-                    'w-7 h-7 flex items-center justify-center rounded',
-                    'hover:bg-card transition-colors',
-                    'text-muted-foreground hover:text-foreground'
-                  )}
+                  className="w-7 h-7"
                   aria-label="Maximize"
                 >
                   <Square size={12} />
-                </button>
+                </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom">Maximize</TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="icon"
                   onClick={() => window.electronAPI?.window.close()}
-                  className={clsx(
-                    'w-7 h-7 flex items-center justify-center rounded',
-                    'hover:bg-destructive/20 transition-colors',
-                    'text-muted-foreground hover:text-destructive'
-                  )}
+                  className="w-7 h-7 hover:bg-destructive/20 hover:text-destructive"
                   aria-label="Close"
                 >
                   <XIcon size={14} />
-                </button>
+                </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom">Close</TooltipContent>
             </Tooltip>

--- a/apps/web/src/components/shared/WelcomeView.tsx
+++ b/apps/web/src/components/shared/WelcomeView.tsx
@@ -6,6 +6,7 @@ import type { ProjectTab } from '@omniscribe/shared';
 import { APP_NAME } from '@omniscribe/shared';
 import { getGreeting, formatRelativeTime } from '@/lib/date-utils';
 import { truncatePath } from '@/lib/path-utils';
+import { Button } from '@/components/ui/button';
 
 interface WelcomeViewProps {
   recentProjects: ProjectTab[];
@@ -112,16 +113,17 @@ export function WelcomeView({
             </div>
             <div className="space-y-2">
               {recentProjects.slice(0, 5).map((project, index) => (
-                <button
+                <Button
                   key={project.id}
+                  variant="outline"
                   onClick={() => onSelectProject(project.id)}
                   className={clsx(
-                    'w-full flex items-center gap-3 px-4 py-3 rounded-lg',
+                    'w-full justify-start h-auto px-4 py-3',
                     'bg-card/50 backdrop-blur-lg',
-                    'border border-border/60',
+                    'border-border/60',
                     'hover:bg-card/80 hover:border-border',
                     'transition-all duration-200',
-                    'text-left group'
+                    'group'
                   )}
                 >
                   <div
@@ -147,17 +149,18 @@ export function WelcomeView({
                   <span className="text-xs text-muted-foreground whitespace-nowrap">
                     {formatRelativeTime(project.lastAccessedAt)}
                   </span>
-                </button>
+                </Button>
               ))}
             </div>
           </div>
         )}
 
         {/* Open Project Action */}
-        <button
+        <Button
+          variant="default"
           onClick={onOpenProject}
           className={clsx(
-            'flex items-center gap-3 px-6 py-3 rounded-xl',
+            'gap-3 px-6 py-3 rounded-xl',
             'bg-gradient-to-r from-primary to-brand-600',
             'text-white font-medium',
             'shadow-lg shadow-primary/25',
@@ -168,7 +171,7 @@ export function WelcomeView({
         >
           <FolderOpen size={20} />
           <span>Open Project</span>
-        </button>
+        </Button>
 
         {/* Keyboard hint */}
         <p className="mt-4 text-xs text-muted-foreground">

--- a/apps/web/src/components/terminal/GridPresetCard.tsx
+++ b/apps/web/src/components/terminal/GridPresetCard.tsx
@@ -1,6 +1,7 @@
 import { clsx } from 'clsx';
 import { useMemo } from 'react';
 import { getLayout } from '@/lib/terminal-layout';
+import { Button } from '@/components/ui/button';
 
 interface GridPresetCardProps {
   count: number;
@@ -13,19 +14,17 @@ export function GridPresetCard({ count, selected, disabled, onClick }: GridPrese
   const layout = useMemo(() => getLayout(count), [count]);
 
   return (
-    <button
-      type="button"
+    <Button
+      variant="outline"
       onClick={onClick}
       disabled={disabled}
       title={`${count} ${count === 1 ? 'session' : 'sessions'}`}
       className={clsx(
-        'flex flex-col items-center p-2.5 rounded-lg',
-        'border transition-all duration-200',
-        'cursor-pointer',
-        disabled && 'opacity-40 cursor-not-allowed',
+        'flex flex-col items-center p-2.5 h-auto',
+        'transition-all duration-200',
         selected
           ? 'border-primary shadow-[0_0_8px_var(--primary)] bg-primary/5'
-          : 'border-border hover:border-muted-foreground bg-card/30 hover:bg-card/50'
+          : 'bg-card/30 hover:bg-card/50'
       )}
     >
       {/* Mini grid preview */}
@@ -46,6 +45,6 @@ export function GridPresetCard({ count, selected, disabled, onClick }: GridPrese
           </div>
         ))}
       </div>
-    </button>
+    </Button>
   );
 }

--- a/apps/web/src/components/terminal/LaunchPresetsModal.tsx
+++ b/apps/web/src/components/terminal/LaunchPresetsModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { clsx } from 'clsx';
 import { Terminal, ChevronDown, X } from 'lucide-react';
 import { Separator } from '@/components/ui/separator';
+import { Button } from '@/components/ui/button';
 import { BranchAutocomplete } from '@/components/shared/BranchAutocomplete';
 import { ClaudeIcon } from '@/components/shared/ClaudeIcon';
 import { useClickOutside } from '@/hooks/useClickOutside';
@@ -118,14 +119,14 @@ export function LaunchPresetsModal({
             </h2>
             <p className="text-sm text-muted-foreground">Choose a layout and configure defaults</p>
           </div>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={() => onOpenChange(false)}
-            className="p-2 rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
             aria-label="Close"
           >
             <X className="w-4 h-4" />
-          </button>
+          </Button>
         </div>
 
         {/* Content */}
@@ -155,16 +156,11 @@ export function LaunchPresetsModal({
             <div className="flex items-center gap-3">
               {/* AI Mode selector */}
               <div ref={dropdownRef} className="relative">
-                <button
-                  type="button"
+                <Button
+                  variant="outline"
+                  size="sm"
                   onClick={() => setIsAIModeOpen(!isAIModeOpen)}
-                  className={clsx(
-                    'flex items-center gap-2 px-2 py-1.5 rounded',
-                    'bg-muted border border-border',
-                    'text-xs text-foreground',
-                    'hover:border-muted-foreground',
-                    'transition-colors min-w-[110px]'
-                  )}
+                  className="min-w-[110px] text-xs"
                 >
                   {aiMode === 'claude' ? (
                     <ClaudeIcon size={14} className="text-orange-400" />
@@ -179,7 +175,7 @@ export function LaunchPresetsModal({
                       isAIModeOpen && 'rotate-180'
                     )}
                   />
-                </button>
+                </Button>
 
                 {isAIModeOpen && (
                   <div
@@ -192,9 +188,10 @@ export function LaunchPresetsModal({
                     {(['claude', 'plain'] as const).map(mode => {
                       const isDisabled = mode === 'claude' && !claudeAvailable;
                       return (
-                        <button
-                          type="button"
+                        <Button
                           key={mode}
+                          variant="ghost"
+                          size="sm"
                           onClick={() => {
                             if (isDisabled) return;
                             setAiMode(mode);
@@ -203,13 +200,8 @@ export function LaunchPresetsModal({
                           disabled={isDisabled}
                           title={isDisabled ? 'Claude CLI is not installed' : undefined}
                           className={clsx(
-                            'w-full flex items-center gap-2 px-3 py-1.5',
-                            'text-xs text-left transition-colors',
-                            isDisabled
-                              ? 'opacity-40 cursor-not-allowed'
-                              : mode === aiMode
-                                ? 'bg-primary/10 text-primary'
-                                : 'text-foreground hover:bg-card'
+                            'w-full justify-start text-xs',
+                            mode === aiMode && 'bg-primary/10 text-primary'
                           )}
                         >
                           {mode === 'claude' ? (
@@ -223,7 +215,7 @@ export function LaunchPresetsModal({
                               Not installed
                             </span>
                           )}
-                        </button>
+                        </Button>
                       );
                     })}
                   </div>
@@ -244,31 +236,12 @@ export function LaunchPresetsModal({
 
         {/* Footer */}
         <div className="flex justify-end gap-2 px-6 pb-6 pt-2">
-          <button
-            type="button"
-            onClick={() => onOpenChange(false)}
-            className={clsx(
-              'px-4 py-2 rounded-md text-sm',
-              'text-muted-foreground hover:text-foreground',
-              'hover:bg-muted transition-colors'
-            )}
-          >
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
-          </button>
-          <button
-            type="button"
-            onClick={handleCreate}
-            disabled={selectedCount === null}
-            className={clsx(
-              'px-4 py-2 rounded-md text-sm font-medium',
-              'transition-colors',
-              selectedCount !== null
-                ? 'bg-primary hover:brightness-110 text-primary-foreground'
-                : 'bg-border text-muted-foreground cursor-not-allowed'
-            )}
-          >
+          </Button>
+          <Button variant="default" onClick={handleCreate} disabled={selectedCount === null}>
             {selectedCount !== null ? `Create ${selectedCount} Sessions` : 'Select a layout'}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/terminal/PreLaunchBar.tsx
+++ b/apps/web/src/components/terminal/PreLaunchBar.tsx
@@ -6,6 +6,7 @@ import type { Branch } from '@/components/shared/BranchSelector';
 import { BranchAutocomplete } from '@/components/shared/BranchAutocomplete';
 import { ClaudeIcon } from '@/components/shared/ClaudeIcon';
 import { getPrelaunchShortcutForIndex } from '@/lib/prelaunch-shortcuts';
+import { Button } from '@/components/ui/button';
 
 export type AIMode = 'claude' | 'plain';
 
@@ -86,15 +87,11 @@ export function PreLaunchBar({
     >
       {/* AI Mode selector */}
       <div ref={aiModeRef} className="relative">
-        <button
+        <Button
+          variant="outline"
+          size="sm"
           onClick={() => setIsAIModeOpen(!isAIModeOpen)}
-          className={clsx(
-            'flex items-center gap-2 px-2 py-1 rounded',
-            'bg-muted border border-border',
-            'text-xs text-foreground',
-            'hover:border-muted-foreground',
-            'transition-colors min-w-[100px]'
-          )}
+          className="min-w-[100px] text-xs"
         >
           <SelectedIcon size={14} className={selectedMode.color} />
           <span data-testid="ai-mode-label">{selectedMode.label}</span>
@@ -105,7 +102,7 @@ export function PreLaunchBar({
               isAIModeOpen && 'rotate-180'
             )}
           />
-        </button>
+        </Button>
 
         {/* AI Mode dropdown */}
         {isAIModeOpen && (
@@ -120,9 +117,10 @@ export function PreLaunchBar({
               const Icon = option.icon;
               const isDisabled = option.value === 'claude' && !claudeAvailable;
               return (
-                <button
-                  type="button"
+                <Button
                   key={option.value}
+                  variant="ghost"
+                  size="sm"
                   onClick={() => {
                     if (isDisabled) return;
                     onUpdate(slot.id, { aiMode: option.value });
@@ -131,13 +129,8 @@ export function PreLaunchBar({
                   disabled={isDisabled}
                   title={isDisabled ? 'Claude CLI is not installed' : undefined}
                   className={clsx(
-                    'w-full flex items-center gap-2 px-3 py-1.5',
-                    'text-xs text-left transition-colors',
-                    isDisabled
-                      ? 'opacity-40 cursor-not-allowed'
-                      : option.value === slot.aiMode
-                        ? 'bg-primary/10 text-primary'
-                        : 'text-foreground hover:bg-card'
+                    'w-full justify-start text-xs',
+                    option.value === slot.aiMode && 'bg-primary/10 text-primary'
                   )}
                 >
                   <Icon size={14} className={option.color} />
@@ -145,7 +138,7 @@ export function PreLaunchBar({
                   {isDisabled && (
                     <span className="ml-auto text-[10px] text-muted-foreground">Not installed</span>
                   )}
-                </button>
+                </Button>
               );
             })}
           </div>
@@ -167,17 +160,12 @@ export function PreLaunchBar({
       <div className="flex-1" />
 
       {/* Launch button */}
-      <button
+      <Button
+        variant="default"
+        size="sm"
         onClick={() => onLaunch(slot.id)}
         disabled={isLaunching}
-        className={clsx(
-          'flex items-center gap-1.5 px-3 py-1 rounded',
-          'text-xs font-medium',
-          'transition-colors',
-          isLaunching
-            ? 'bg-border text-muted-foreground cursor-not-allowed opacity-60'
-            : 'bg-primary hover:brightness-110 text-primary-foreground'
-        )}
+        className="text-xs"
         title={shortcutKey ? `Press ${shortcutKey} to launch` : undefined}
       >
         <Play size={12} fill="currentColor" />
@@ -185,20 +173,18 @@ export function PreLaunchBar({
         {shortcutKey && !isLaunching && (
           <kbd className="ml-1 px-1 py-0.5 text-[10px] bg-white/20 rounded">{shortcutKey}</kbd>
         )}
-      </button>
+      </Button>
 
       {/* Remove button */}
-      <button
+      <Button
+        variant="ghost"
+        size="icon"
         onClick={() => onRemove(slot.id)}
-        className={clsx(
-          'p-1 rounded',
-          'text-muted-foreground hover:text-red-400',
-          'hover:bg-red-400/10 transition-colors'
-        )}
+        className="text-muted-foreground hover:text-red-400 hover:bg-red-400/10"
         aria-label="Remove"
       >
         <X size={14} />
-      </button>
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace raw `<button>` elements with shadcn `<Button>` component across 7 files for consistent styling, focus states, and disabled behavior
- Simplify IdleLandingView CTA to `Button size="icon"`
- Convert all TopBar action/tab/window buttons to `Button variant="ghost"`
- Update WelcomeView recent project items and open project CTA
- Refactor LaunchPresetsModal close, cancel, create, and AI mode selector buttons
- Consolidate PreLaunchBar AI mode, launch, and remove buttons
- Update GridPresetCard layout presets to `Button variant="outline"`
- Update InstallCommandDisplay copy and run buttons

Net result: **-90 lines** by removing ad-hoc `clsx` styling in favor of shadcn Button variants.

## Test plan
- [x] Verify IdleLandingView plus button renders and opens launch modal
- [x] Verify all TopBar icon buttons work (settings, set up, add, stop, launch, window controls)
- [x] Test WelcomeView recent projects selection and Open Project button
- [x] Test LaunchPresetsModal: open/close, layout selection, AI mode dropdown, cancel/create
- [x] Test PreLaunchBar: AI mode toggle, branch selector, launch, remove
- [x] Verify GridPresetCard selection highlights with primary border
- [x] Test InstallCommandDisplay copy and run-in-terminal buttons
- [x] Confirm disabled states render correctly (Launch when no slots, Create when no layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)