### PR TITLE
fix: make toast follow active theme colors

### DIFF
--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -1,7 +1,11 @@
+import { useEffect } from 'react';
 import { Toaster as Sonner } from 'sonner';
 
+import { createLogger } from '@omniscribe/shared';
 import { getThemeOption } from '@/lib/theme';
 import { useSettingsStore, selectEffectiveTheme } from '@/stores/useSettingsStore';
+
+const logger = createLogger('Toaster');
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
@@ -9,11 +13,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
   const effectiveTheme = useSettingsStore(selectEffectiveTheme);
   const themeOption = getThemeOption(effectiveTheme);
 
-  if (!themeOption && import.meta.env.DEV) {
-    console.warn(
-      `[Toaster] Theme "${effectiveTheme}" not found in themeOptions, defaulting to dark`
-    );
-  }
+  useEffect(() => {
+    if (!themeOption && import.meta.env.DEV) {
+      logger.warn(`Theme "${effectiveTheme}" not found in themeOptions, defaulting to dark`);
+    }
+  }, [effectiveTheme, themeOption]);
 
   const isDark = themeOption?.isDark ?? true;
 


### PR DESCRIPTION
## Summary
- Sonner toast was hardcoded to `theme="dark"`, causing it to always use `--normal-bg: #000` regardless of the active theme
- Now dynamically detects dark/light from the active theme via `useSettingsStore` and `getThemeOption()`
- Remaps Sonner's internal CSS variables (`--normal-bg`, `--normal-border`, `--normal-text`) to the project's theme CSS variables (`--background`, `--border`, `--foreground`)

## Test plan
- [ ] Select a distinctive dark theme (e.g., Dracula, Catppuccin) and trigger a toast — background should match the theme
- [ ] Switch to a light theme (e.g., GitHub, Paper) and trigger a toast — should render with light colors
- [ ] Rapidly switch themes and verify the toast follows each time
- [ ] Verify success/error/warning toasts still display their colored variants correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toast notifications now automatically match the app theme, switching between light and dark modes based on your settings.
  * Notification appearance is now mapped to the app’s CSS variables for improved visual consistency with your chosen color scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->