### PR TITLE
refactor: extract UsageOutputParser from UsageService

### DIFF
--- a/apps/desktop/src/modules/usage/index.ts
+++ b/apps/desktop/src/modules/usage/index.ts
@@ -1,4 +1,3 @@
 export { UsageModule } from './usage.module';
 export { UsageService } from './usage.service';
 export { UsageGateway } from './usage.gateway';
-export { UsageOutputParser, stripAnsiCodes } from './usage-output-parser';

--- a/apps/desktop/src/modules/usage/usage-output-parser.spec.ts
+++ b/apps/desktop/src/modules/usage/usage-output-parser.spec.ts
@@ -348,17 +348,15 @@ describe('UsageOutputParser', () => {
       // When percentage and reset are on the same line
       const usage = parser.parseUsageOutput('Current session\n  25% used  Resets in 2h 15m\n');
 
-      if (usage.sessionResetText) {
-        expect(usage.sessionResetText).not.toMatch(/\d+%/);
-      }
+      expect(usage.sessionResetText).toBeTruthy();
+      expect(usage.sessionResetText).not.toMatch(/\d+%/);
     });
 
     it('should fix missing space between "Resets" and number', () => {
       const usage = parser.parseUsageOutput('Current session\n  25% used\n  Resets2h 15m\n');
 
-      if (usage.sessionResetText) {
-        expect(usage.sessionResetText).toMatch(/Resets?\s+\d/);
-      }
+      expect(usage.sessionResetText).toBeTruthy();
+      expect(usage.sessionResetText).toMatch(/Resets?\s+\d/);
     });
   });
 });

--- a/apps/desktop/src/modules/usage/usage-output-parser.ts
+++ b/apps/desktop/src/modules/usage/usage-output-parser.ts
@@ -1,5 +1,8 @@
 import type { ClaudeUsage } from '@omniscribe/shared';
 
+/** Valid usage section types */
+type UsageType = 'session' | 'weekly' | 'sonnet';
+
 // ---- Regex patterns ----
 
 /** Matches percentage values: "25% used", "75% left", "60% remaining" */
@@ -14,8 +17,8 @@ const TIMEZONE_SUFFIX_REGEX = /\s*\([A-Za-z_/]+\)\s*$/;
 /** Matches missing space between "Resets" and a digit */
 const MISSING_SPACE_REGEX = /(resets?)(\d)/i;
 
-/** Matches duration format: "2h 15m", "3h", "45m", "2hours", "45min" */
-const DURATION_REGEX = /(\d+)\s*h(?:ours?)?(?:\s+(\d+)\s*m(?:in)?)?|(\d+)\s*m(?:in)?/i;
+/** Matches duration format: "in 2h 15m", "in 3h", "in 45m", "in 2hours", "in 45min" */
+const DURATION_REGEX = /\bin\s+(?:(\d+)\s*h(?:ours?)?(?:\s+(\d+)\s*m(?:in)?)?|(\d+)\s*m(?:in)?)/i;
 
 /** Matches simple time format: "Resets 11am", "Resets 3:30pm" */
 const SIMPLE_TIME_REGEX = /resets\s*(\d{1,2})(?::(\d{2}))?\s*(am|pm)/i;
@@ -56,11 +59,16 @@ export function stripAnsiCodes(text: string): string {
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n');
 
-  // Handle backspaces
-  while (clean.includes('\x08')) {
-    clean = clean.replace(/[^\x08]\x08/, '');
-    clean = clean.replace(/^\x08+/, '');
+  // Handle backspaces (single-pass)
+  const chars: string[] = [];
+  for (const char of clean) {
+    if (char === '\x08') {
+      chars.pop();
+    } else {
+      chars.push(char);
+    }
   }
+  clean = chars.join('');
 
   // Strip remaining control characters (except newline)
   clean = clean.replace(/[\x00-\x08\x0B-\x1F\x7F]/g, '');
@@ -93,25 +101,22 @@ export class UsageOutputParser {
     const weeklyData = this.parseSection(lines, 'Current week (all models)', 'weekly');
 
     // Parse Sonnet/Opus usage - try different labels
-    let sonnetData = this.parseSection(lines, 'Current week (Sonnet only)', 'sonnet');
-    if (sonnetData.percentage === 0) {
-      sonnetData = this.parseSection(lines, 'Current week (Sonnet)', 'sonnet');
-    }
-    if (sonnetData.percentage === 0) {
-      sonnetData = this.parseSection(lines, 'Current week (Opus)', 'sonnet');
-    }
+    const sonnetData =
+      this.parseSection(lines, 'Current week (Sonnet only)', 'sonnet') ??
+      this.parseSection(lines, 'Current week (Sonnet)', 'sonnet') ??
+      this.parseSection(lines, 'Current week (Opus)', 'sonnet');
 
     return {
-      sessionPercentage: sessionData.percentage,
-      sessionResetTime: sessionData.resetTime,
-      sessionResetText: sessionData.resetText,
+      sessionPercentage: sessionData?.percentage ?? 0,
+      sessionResetTime: sessionData?.resetTime ?? this.getDefaultResetTime('session'),
+      sessionResetText: sessionData?.resetText ?? '',
 
-      weeklyPercentage: weeklyData.percentage,
-      weeklyResetTime: weeklyData.resetTime,
-      weeklyResetText: weeklyData.resetText,
+      weeklyPercentage: weeklyData?.percentage ?? 0,
+      weeklyResetTime: weeklyData?.resetTime ?? this.getDefaultResetTime('weekly'),
+      weeklyResetText: weeklyData?.resetText ?? '',
 
-      sonnetWeeklyPercentage: sonnetData.percentage,
-      sonnetResetText: sonnetData.resetText,
+      sonnetWeeklyPercentage: sonnetData?.percentage ?? 0,
+      sonnetResetText: sonnetData?.resetText ?? '',
 
       lastUpdated: new Date().toISOString(),
       userTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -124,8 +129,8 @@ export class UsageOutputParser {
   private parseSection(
     lines: string[],
     sectionLabel: string,
-    type: string
-  ): { percentage: number; resetTime: string; resetText: string } {
+    type: UsageType
+  ): { percentage: number; resetTime: string; resetText: string } | null {
     let percentage: number | null = null;
     let resetTime = this.getDefaultResetTime(type);
     let resetText = '';
@@ -140,7 +145,7 @@ export class UsageOutputParser {
     }
 
     if (sectionIndex === -1) {
-      return { percentage: 0, resetTime, resetText };
+      return null;
     }
 
     // Look at the lines following the section header
@@ -184,7 +189,7 @@ export class UsageOutputParser {
   /**
    * Parse reset time from text like "Resets in 2h 15m" or "Resets Dec 22 at 8pm"
    */
-  private parseResetTime(text: string, type: string): string {
+  private parseResetTime(text: string, type: UsageType): string {
     const now = new Date();
 
     // Try duration format: "Resets in 2h 15m"
@@ -239,6 +244,7 @@ export class UsageOutputParser {
 
       if (month !== undefined) {
         const year = now.getFullYear();
+        // Intentionally uses local time — the CLI outputs times in the user's timezone
         const resetDate = new Date(year, month, day, hours, minutes);
         if (resetDate < now) {
           resetDate.setFullYear(year + 1);
@@ -253,7 +259,7 @@ export class UsageOutputParser {
   /**
    * Get default reset time based on usage type
    */
-  private getDefaultResetTime(type: string): string {
+  private getDefaultResetTime(type: UsageType): string {
     const now = new Date();
 
     if (type === 'session') {

--- a/apps/desktop/src/modules/usage/usage.service.ts
+++ b/apps/desktop/src/modules/usage/usage.service.ts
@@ -161,12 +161,13 @@ export class UsageService {
 
       let hasSentCommand = false;
       let hasApprovedTrust = false;
+      let cleanOutput = '';
 
       ptyProcess.onData((data: string) => {
         output += data;
 
-        // Strip ANSI codes for easier matching
-        const cleanOutput = stripAnsiCodes(output);
+        // Strip ANSI codes from the new chunk and append to clean buffer
+        cleanOutput += stripAnsiCodes(data);
 
         // Check for authentication errors
         const hasAuthError =


### PR DESCRIPTION
## Summary
- Extracted 5 stateless parsing methods from `UsageService` (532→292 lines) into a standalone `UsageOutputParser` class
- Exported `stripAnsiCodes()` as a standalone function used by both the parser and the service
- Migrated 34 parsing tests to test the parser directly without PTY mocking
- All regex patterns extracted as named module-level constants for readability

## Test plan
- [x] `pnpm typecheck` passes across all packages
- [x] `pnpm lint` passes (0 errors)
- [x] All 102 usage tests pass (3 test suites)
- [x] `usage.service.ts` reduced from 532 to 292 lines
- [x] Parser tests call `parser.parseUsageOutput()` directly — no PTY mocking needed

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted usage output parsing logic into a dedicated, independently-tested module for improved code organization.

* **Tests**
  * Comprehensive test suite added covering usage parsing scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->