### PR TITLE
fix(workspace): show granular session status on project tabs

### DIFF
--- a/apps/web/src/hooks/__tests__/useWorkspaceTabs.test.ts
+++ b/apps/web/src/hooks/__tests__/useWorkspaceTabs.test.ts
@@ -109,14 +109,14 @@ describe('useWorkspaceTabs', () => {
   // ---- tab status ----
 
   describe('tab status', () => {
-    it('is idle when there are no sessions', () => {
+    it('is undefined when there are no sessions', () => {
       setupTabs();
       mockSessions = [];
 
       const { result } = renderHook(() => useWorkspaceTabs());
 
-      expect(result.current.tabs[0].status).toBe('idle');
-      expect(result.current.tabs[1].status).toBe('idle');
+      expect(result.current.tabs[0].status).toBeUndefined();
+      expect(result.current.tabs[1].status).toBeUndefined();
     });
 
     it('is idle when all sessions for the project are idle', () => {
@@ -167,22 +167,85 @@ describe('useWorkspaceTabs', () => {
       expect(result.current.tabs[0].status).toBe('working');
     });
 
-    it('is working when a session has needs_input status', () => {
+    it('is needsInput when a session has needs_input status', () => {
       setupTabs();
       mockSessions = [{ id: 's1', projectPath: '/path/a', status: 'needs_input' }];
 
       const { result } = renderHook(() => useWorkspaceTabs());
 
-      expect(result.current.tabs[0].status).toBe('working');
+      expect(result.current.tabs[0].status).toBe('needsInput');
     });
 
-    it('is working when a session has error status', () => {
+    it('is error when a session has error status', () => {
       setupTabs();
       mockSessions = [{ id: 's1', projectPath: '/path/a', status: 'error' }];
 
       const { result } = renderHook(() => useWorkspaceTabs());
 
-      expect(result.current.tabs[0].status).toBe('working');
+      expect(result.current.tabs[0].status).toBe('error');
+    });
+
+    it('is done when a session has finished status', () => {
+      setupTabs();
+      mockSessions = [{ id: 's1', projectPath: '/path/a', status: 'finished' }];
+
+      const { result } = renderHook(() => useWorkspaceTabs());
+
+      expect(result.current.tabs[0].status).toBe('done');
+    });
+
+    it('is starting when a session has connecting status', () => {
+      setupTabs();
+      mockSessions = [{ id: 's1', projectPath: '/path/a', status: 'connecting' }];
+
+      const { result } = renderHook(() => useWorkspaceTabs());
+
+      expect(result.current.tabs[0].status).toBe('starting');
+    });
+
+    it('is planning when a session has planning status', () => {
+      setupTabs();
+      mockSessions = [{ id: 's1', projectPath: '/path/a', status: 'planning' }];
+
+      const { result } = renderHook(() => useWorkspaceTabs());
+
+      expect(result.current.tabs[0].status).toBe('planning');
+    });
+
+    it('shows error over working when both exist (priority)', () => {
+      setupTabs();
+      mockSessions = [
+        { id: 's1', projectPath: '/path/a', status: 'working' },
+        { id: 's2', projectPath: '/path/a', status: 'error' },
+      ];
+
+      const { result } = renderHook(() => useWorkspaceTabs());
+
+      expect(result.current.tabs[0].status).toBe('error');
+    });
+
+    it('shows needsInput over working when both exist (priority)', () => {
+      setupTabs();
+      mockSessions = [
+        { id: 's1', projectPath: '/path/a', status: 'working' },
+        { id: 's2', projectPath: '/path/a', status: 'needs_input' },
+      ];
+
+      const { result } = renderHook(() => useWorkspaceTabs());
+
+      expect(result.current.tabs[0].status).toBe('needsInput');
+    });
+
+    it('shows done over idle when both exist (priority)', () => {
+      setupTabs();
+      mockSessions = [
+        { id: 's1', projectPath: '/path/a', status: 'idle' },
+        { id: 's2', projectPath: '/path/a', status: 'finished' },
+      ];
+
+      const { result } = renderHook(() => useWorkspaceTabs());
+
+      expect(result.current.tabs[0].status).toBe('done');
     });
 
     it('only considers sessions matching the tab projectPath', () => {
@@ -206,8 +269,8 @@ describe('useWorkspaceTabs', () => {
 
       const { result } = renderHook(() => useWorkspaceTabs());
 
-      expect(result.current.tabs[0].status).toBe('idle');
-      expect(result.current.tabs[1].status).toBe('idle');
+      expect(result.current.tabs[0].status).toBeUndefined();
+      expect(result.current.tabs[1].status).toBeUndefined();
     });
   });
 

--- a/apps/web/src/hooks/useWorkspaceTabs.ts
+++ b/apps/web/src/hooks/useWorkspaceTabs.ts
@@ -1,12 +1,21 @@
 import { useCallback, useMemo } from 'react';
 import { arrayMove } from '@dnd-kit/sortable';
-import { createLogger } from '@omniscribe/shared';
+import { createLogger, mapSessionStatus, type UISessionStatus } from '@omniscribe/shared';
 import { useWorkspaceStore, type ProjectTab } from '@/stores/useWorkspaceStore';
 import { useSessionStore } from '@/stores/useSessionStore';
 import type { Tab } from '@/components';
-import type { UISessionStatus } from '@omniscribe/shared';
 
 const logger = createLogger('WorkspaceTabs');
+
+const STATUS_PRIORITY: Record<UISessionStatus, number> = {
+  idle: 0,
+  done: 1,
+  starting: 2,
+  planning: 3,
+  working: 4,
+  needsInput: 5,
+  error: 6,
+};
 
 interface UseWorkspaceTabsReturn {
   /** All workspace tabs in UI format */
@@ -55,17 +64,21 @@ export function useWorkspaceTabs(): UseWorkspaceTabsReturn {
   // Convert workspace tabs to UI tabs format
   const tabs: Tab[] = useMemo(() => {
     return workspaceTabs.map(tab => {
-      // Count sessions for this project
       const projectSessions = sessions.filter(s => s.projectPath === tab.projectPath);
-      const hasActive = projectSessions.some(
-        s => s.status !== 'idle' && s.status !== 'disconnected'
-      );
+      if (projectSessions.length === 0) {
+        return { id: tab.id, label: tab.name, status: undefined };
+      }
 
-      return {
-        id: tab.id,
-        label: tab.name,
-        status: hasActive ? ('working' as UISessionStatus) : ('idle' as UISessionStatus),
-      };
+      // Pick the highest-priority status across all sessions
+      let topStatus: UISessionStatus = 'idle';
+      for (const session of projectSessions) {
+        const uiStatus = mapSessionStatus(session.status);
+        if (STATUS_PRIORITY[uiStatus] > STATUS_PRIORITY[topStatus]) {
+          topStatus = uiStatus;
+        }
+      }
+
+      return { id: tab.id, label: tab.name, status: topStatus };
     });
   }, [workspaceTabs, sessions]);
 


### PR DESCRIPTION
## Summary
- Replace binary working/idle tab status with priority-based aggregation using `mapSessionStatus()`
- Tabs now correctly show done (green), needsInput (yellow), error (red), planning (purple), and starting (orange) status dots
- Tabs with zero sessions show no status dot instead of idle

## Test plan
- [x] Updated 4 existing test assertions to match new granular behavior
- [x] Added 6 new tests: finished→done, connecting→starting, planning→planning, and 3 priority aggregation tests
- [x] All 1348 frontend tests pass
- [x] Typecheck clean across all packages
- [ ] Manual: open multiple sessions, verify tab dots match StatusBar legend colors

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated workspace tab status indicators to display the most critical session status when multiple sessions are active.
  * Implemented priority rules where error and input-needed states take precedence over working states.
  
* **New Features**
  * Tab status labels updated with improved naming for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->