### PR TITLE
fix(frontend): use theme system colors in splash screen

### DIFF
--- a/apps/web/src/components/splash/SplashScreen.tsx
+++ b/apps/web/src/components/splash/SplashScreen.tsx
@@ -1,5 +1,4 @@
 import { Loader2 } from 'lucide-react';
-import { cn } from '@/lib/utils';
 import { useSplashScreen } from '@/hooks/useSplashScreen';
 
 /**
@@ -10,19 +9,13 @@ import { useSplashScreen } from '@/hooks/useSplashScreen';
  * once the app is ready (or after a 10s safety timeout).
  */
 export function SplashScreen() {
-  const { isVisible, isDismissing, showSpinner, statusText, version, isDarkTheme } =
-    useSplashScreen();
+  const { isVisible, isDismissing, showSpinner, statusText, version } = useSplashScreen();
 
   if (!isVisible) return null;
 
   return (
     <div
-      className={cn(
-        'fixed inset-0 z-9999 flex flex-col items-center justify-center',
-        isDarkTheme
-          ? 'bg-linear-to-br from-[#0a0a0f] via-[#0a0a0f] to-[#1a1a2e]'
-          : 'bg-linear-to-br from-[#fafafa] via-[#ffffff] to-[#f0f0ff]'
-      )}
+      className="fixed inset-0 z-9999 flex flex-col items-center justify-center bg-background"
       style={{
         opacity: isDismissing ? 0 : 1,
         transform: isDismissing ? 'scale(1.02)' : 'scale(1)',
@@ -39,14 +32,7 @@ export function SplashScreen() {
 
       {/* Version label */}
       {version && (
-        <span
-          className={cn(
-            'mt-3 rounded-full px-2.5 py-0.5 text-[10px] font-medium tracking-wide select-none',
-            isDarkTheme
-              ? 'bg-indigo-500/10 text-indigo-400 ring-1 ring-indigo-500/20'
-              : 'bg-indigo-500/10 text-indigo-600 ring-1 ring-indigo-500/20'
-          )}
-        >
+        <span className="mt-3 rounded-full px-2.5 py-0.5 text-[10px] font-medium tracking-wide select-none bg-brand-500/10 text-brand-400 ring-1 ring-brand-500/20">
           v{version}
         </span>
       )}
@@ -61,13 +47,8 @@ export function SplashScreen() {
         role="status"
         aria-live="polite"
       >
-        <Loader2
-          className={cn(
-            'h-5 w-5 animate-spin',
-            isDarkTheme ? 'text-indigo-400' : 'text-indigo-500'
-          )}
-        />
-        <p className="text-sm select-none text-zinc-500">{statusText}</p>
+        <Loader2 className="h-5 w-5 animate-spin text-brand-400" />
+        <p className="text-sm select-none text-foreground-muted">{statusText}</p>
       </div>
     </div>
   );

--- a/apps/web/src/hooks/__tests__/hooks-batch2.test.ts
+++ b/apps/web/src/hooks/__tests__/hooks-batch2.test.ts
@@ -716,11 +716,6 @@ describe('useSplashScreen', () => {
       useAppVersion: () => '1.0.0',
     }));
 
-    vi.doMock('@/lib/theme-persistence', () => ({
-      getPersistedTheme: () => 'dark',
-      isPersistedThemeDark: () => true,
-    }));
-
     const mod = await import('../useSplashScreen');
     return renderHook(() => mod.useSplashScreen());
   }
@@ -732,7 +727,6 @@ describe('useSplashScreen', () => {
     expect(result.current).toHaveProperty('showSpinner');
     expect(result.current).toHaveProperty('statusText');
     expect(result.current).toHaveProperty('version');
-    expect(result.current).toHaveProperty('isDarkTheme');
   });
 
   it('is initially visible and not dismissing', async () => {

--- a/apps/web/src/hooks/useSplashScreen.ts
+++ b/apps/web/src/hooks/useSplashScreen.ts
@@ -2,7 +2,6 @@ import { useState, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 import { useConnectionStore } from '@/stores/useConnectionStore';
 import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
-import { getPersistedTheme, isPersistedThemeDark } from '@/lib/theme-persistence';
 import { useAppVersion } from './useAppVersion';
 
 /** Minimum time the splash screen stays visible (ms) */
@@ -25,8 +24,6 @@ export interface SplashScreenState {
   statusText: string;
   /** App version string (empty in dev mode) */
   version: string;
-  /** Whether the current persisted theme is dark */
-  isDarkTheme: boolean;
 }
 
 /**
@@ -49,7 +46,6 @@ export function useSplashScreen(): SplashScreenState {
   const [isDismissing, setIsDismissing] = useState(false);
   const [isVisible, setIsVisible] = useState(true);
   const version = useAppVersion();
-  const [isDarkTheme] = useState(() => isPersistedThemeDark(getPersistedTheme()));
 
   const hasDismissedRef = useRef(false);
 
@@ -98,7 +94,7 @@ export function useSplashScreen(): SplashScreenState {
   // Status text based on current readiness signals
   const statusText = deriveStatusText(connectionStatus, isWorkspaceRestored);
 
-  return { isVisible, isDismissing, showSpinner, statusText, version, isDarkTheme };
+  return { isVisible, isDismissing, showSpinner, statusText, version };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace hardcoded hex colors and `isDarkTheme` conditionals in the splash screen with theme-aware Tailwind utilities (`bg-background`, `text-brand-400`, `text-foreground-muted`, etc.)
- Remove the `isDarkTheme` state, imports, and interface property from `useSplashScreen` hook
- Update tests to remove `theme-persistence` mocks and `isDarkTheme` assertions

Closes #170

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1348/1348)
- [ ] Manual: switch to various themes (Dracula, Forest, Rose, Nord), restart app, confirm splash screen uses theme colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)