### PR TITLE
feat(ui): redesign workspace tabs to pill-shaped style

### DIFF
--- a/apps/web/src/components/shared/ProjectTabs.tsx
+++ b/apps/web/src/components/shared/ProjectTabs.tsx
@@ -66,11 +66,11 @@ function SortableTab({
       tabIndex={isActive ? 0 : -1}
       aria-selected={isActive}
       className={cn(
-        'no-drag group flex items-center gap-2 px-3 h-full min-w-0',
-        'cursor-pointer transition-colors border-r border-border',
+        'no-drag group flex items-center gap-2 px-3 h-7 min-w-0',
+        'cursor-pointer transition-colors rounded-lg',
         isActive
-          ? 'bg-card text-foreground'
-          : 'text-foreground-secondary hover:bg-card/50 hover:text-foreground'
+          ? 'bg-card text-foreground shadow-sm'
+          : 'text-foreground-secondary hover:bg-muted-foreground/10 hover:text-foreground'
       )}
       onClick={() => onSelectTab(tab.id)}
       onKeyDown={e => {
@@ -146,7 +146,10 @@ export function ProjectTabs({
   const draggedTab = activeDragId ? tabs.find(t => t.id === activeDragId) : null;
 
   return (
-    <div className="flex items-center overflow-x-auto no-scrollbar shrink min-w-0" role="tablist">
+    <div
+      className="flex items-center gap-1 py-1 px-1 overflow-x-auto no-scrollbar shrink min-w-0"
+      role="tablist"
+    >
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
@@ -171,8 +174,8 @@ export function ProjectTabs({
           {draggedTab ? (
             <div
               className={cn(
-                'no-drag flex items-center gap-2 px-3 h-11 min-w-0',
-                'bg-card text-foreground border border-border rounded shadow-lg'
+                'no-drag flex items-center gap-2 px-3 h-7 min-w-0',
+                'bg-card text-foreground border border-border rounded-lg shadow-lg'
               )}
             >
               {draggedTab.status && <StatusDot status={draggedTab.status} />}
@@ -189,7 +192,7 @@ export function ProjectTabs({
             size="icon"
             data-testid="new-tab-button"
             onClick={onNewTab}
-            className="no-drag px-3 h-full"
+            className="no-drag px-2 h-7 w-7 rounded-lg"
             aria-label="New tab"
           >
             <Plus size={16} />


### PR DESCRIPTION
## Summary
- Redesigns workspace tabs from flat rectangles with border separators to modern Termius-style pill-shaped tabs
- Adds `rounded-lg` corners, fixed `h-7` height, `gap-1` spacing, and `shadow-sm` elevation on active tab
- Updates DragOverlay and "+" button to match the new pill aesthetic

Closes #197

## Changes
**`apps/web/src/components/shared/ProjectTabs.tsx`**
- **SortableTab**: `h-full` → `h-7`, removed `border-r border-border`, added `rounded-lg` and `shadow-sm` (active)
- **Tab container**: Added `gap-1 py-1 px-1` for pill spacing and vertical centering
- **DragOverlay**: `h-11` → `h-7`, `rounded` → `rounded-lg`
- **"+" button**: `h-full` → `h-7 w-7`, added `rounded-lg`

## Test plan
- [x] All 1366 unit tests passing
- [x] Typecheck clean across all packages
- [x] Lint passes (0 errors)
- [ ] Visual QA: pill shape, active/inactive states, hover effects
- [ ] Visual QA: drag-and-drop overlay matches pill styling
- [ ] Visual QA: retro theme shows square tabs (border-radius override)
- [ ] Visual QA: horizontal scroll with 5+ tabs works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tab styling with smaller height and rounded corners for a more compact appearance
  * Enhanced tab interactions with subtle shadows and improved visual hierarchy
  * Refined new tab button with updated sizing and spacing

* **Refactor**
  * Adjusted container padding and layout gaps for improved visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->