### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master, 'v[0-9]+.[0-9]+.[0-9]+']


### PR DESCRIPTION
Potential fix for [https://github.com/Shironex/omniscribe/security/code-scanning/9](https://github.com/Shironex/omniscribe/security/code-scanning/9)

In general, the fix is to explicitly set `permissions` for the `GITHUB_TOKEN` to the minimal required scope instead of relying on the repository’s default. Since this workflow only checks out code, builds, runs tests, and uploads artifacts, it only needs read access to repository contents and no write permissions. The best fix with no functional change is to add a `permissions: contents: read` block at the top level of the workflow so it applies to all jobs, including `e2e`. This documents the intent and prevents accidental over-privileging if defaults are broad or change later.

Concretely, in `.github/workflows/ci.yml`, insert a workflow-level `permissions` section after the `name: CI` line (line 1) and before the `on:` block (line 3). Set it to:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to adjust permissions settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->