### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 9 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Shironex/omniscribe/security/code-scanning/6](https://github.com/Shironex/omniscribe/security/code-scanning/6)

In general, the fix is to explicitly define a `permissions` block for the workflow or for the `audit` job that grants only the minimal scopes needed. For this job, the only requirement is to read repository contents so that the code can be checked out and audited; no write operations to GitHub resources are performed.

The best minimal change, without altering existing functionality, is to add a `permissions` section at the top level of the workflow (applies to all jobs) with `contents: read`. This goes after the `on:` block and before `jobs:`. No other scopes (like `issues`, `pull-requests`, etc.) are needed based on the provided steps. We do not need to change any steps or add imports/dependencies, just the YAML configuration.

Concretely, in `.github/workflows/security-audit.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `schedule` block and the `jobs:` key (i.e., after line 11 and before line 13).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security by implementing explicit permissions for automated workflows, restricting access to repository contents with a read-only scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->