### PR TITLE
feat(idle-view): redesign welcome view with recent sessions and richer titles

### DIFF
--- a/apps/desktop/src/modules/session/claude-session-reader.service.ts
+++ b/apps/desktop/src/modules/session/claude-session-reader.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as readline from 'readline';
 import {
   ClaudeSessionEntry,
   ClaudeSessionsIndex,
@@ -20,6 +19,7 @@ interface JsonlLineData {
   type?: string;
   isSidechain?: boolean;
   cwd?: string;
+  customTitle?: string;
   message?: { role?: string; content?: string | Array<{ type: string; text?: string }> };
 }
 
@@ -39,6 +39,9 @@ export class ClaudeSessionReaderService implements OnModuleDestroy {
 
   /** Active file watchers keyed by project path, for cleanup on destroy */
   private watchers = new Map<string, fs.FSWatcher>();
+
+  /** Cache of customTitle keyed by "<sessionId>:<fileMtime>" to avoid re-reads */
+  private customTitleCache = new Map<string, string>();
 
   onModuleDestroy(): void {
     // Close all active file watchers
@@ -86,8 +89,14 @@ export class ClaudeSessionReaderService implements OnModuleDestroy {
       this.logger.warn(`Failed to scan .jsonl files: ${errorMessage}`);
     }
 
-    // Step 3: Merge and return
-    const allEntries = [...indexEntries, ...scannedEntries];
+    // Step 3: Merge — scanned entries already have customTitle from JSONL scan.
+    // For index entries (which come from sessions-index.json and never carry customTitle),
+    // do a lazy single-pass JSONL read to populate the field.
+    const populatedIndexEntries = await Promise.all(
+      indexEntries.map(entry => this.populateCustomTitle(entry, sessionsDir))
+    );
+
+    const allEntries = [...populatedIndexEntries, ...scannedEntries];
     return this.filterAndSort(allEntries);
   }
 
@@ -272,22 +281,24 @@ export class ClaudeSessionReaderService implements OnModuleDestroy {
     const sessionId = filename.replace('.jsonl', '');
 
     try {
-      const fileStream = fs.createReadStream(filePath, { encoding: 'utf-8' });
-      const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+      // Read all lines but only keep the first 50 and last 50 to bound memory
+      const content = await fs.promises.readFile(filePath, 'utf-8');
+      const allLines = content.split(/\r?\n/).filter(l => l.trim());
+      const HEAD = 50;
+      const TAIL = 50;
+      const lines =
+        allLines.length <= HEAD + TAIL
+          ? allLines
+          : [...allLines.slice(0, HEAD), ...allLines.slice(-TAIL)];
 
-      let lineCount = 0;
       let extractedSessionId: string | undefined;
       let gitBranch = '';
       let firstTimestamp: string | undefined;
       let firstPrompt = '';
       let isSidechain = false;
+      let customTitle = '';
 
-      for await (const line of rl) {
-        if (lineCount >= 20) break; // Only read first 20 lines
-        lineCount++;
-
-        if (!line.trim()) continue;
-
+      for (const line of lines) {
         try {
           const data: JsonlLineData = JSON.parse(line);
 
@@ -303,6 +314,11 @@ export class ClaudeSessionReaderService implements OnModuleDestroy {
           }
           if (data.timestamp && !firstTimestamp) {
             firstTimestamp = data.timestamp;
+          }
+
+          // Track last custom-title entry — /rename can fire multiple times
+          if (data.type === 'custom-title' && typeof data.customTitle === 'string') {
+            customTitle = data.customTitle;
           }
 
           // Extract first user prompt
@@ -322,7 +338,21 @@ export class ClaudeSessionReaderService implements OnModuleDestroy {
         }
       }
 
-      rl.close();
+      // Count messages across all lines (not just the head+tail window)
+      let messageCount = 0;
+      for (const line of allLines) {
+        try {
+          const data = JSON.parse(line) as JsonlLineData;
+          if (
+            (data.type === 'user' && data.message?.role === 'user') ||
+            data.type === 'assistant'
+          ) {
+            messageCount++;
+          }
+        } catch {
+          // skip unparseable lines
+        }
+      }
 
       // Must have at least a session ID (from filename or content)
       const finalSessionId = extractedSessionId ?? sessionId;
@@ -335,17 +365,63 @@ export class ClaudeSessionReaderService implements OnModuleDestroy {
         fileMtime: mtimeMs,
         firstPrompt: firstPrompt || 'No prompt',
         summary: '', // Summary requires full file analysis; leave empty for scanned entries
-        messageCount: 0, // Unknown without full scan
+        messageCount,
         created,
         modified: new Date(mtimeMs).toISOString(), // Use file mtime as most accurate modified time
         gitBranch,
         projectPath,
         isSidechain,
+        ...(customTitle ? { customTitle } : {}),
       };
     } catch (error) {
       const msg = extractErrorMessage(error);
       this.logger.debug(`Failed to extract entry from ${filename}: ${msg}`);
       return null;
+    }
+  }
+
+  /**
+   * Populate customTitle for a sessions-index.json entry by scanning its JSONL.
+   * Results are cached by sessionId+fileMtime to avoid repeated disk reads.
+   */
+  private async populateCustomTitle(
+    entry: ClaudeSessionEntry,
+    sessionsDir: string
+  ): Promise<ClaudeSessionEntry> {
+    const cacheKey = `${entry.sessionId}:${entry.fileMtime}`;
+    if (this.customTitleCache.has(cacheKey)) {
+      const cached = this.customTitleCache.get(cacheKey)!;
+      return cached ? { ...entry, customTitle: cached } : entry;
+    }
+
+    const filePath = path.join(sessionsDir, `${entry.sessionId}.jsonl`);
+    try {
+      const content = await fs.promises.readFile(filePath, 'utf-8');
+      const allLines = content.split(/\r?\n/).filter(l => l.trim());
+      const HEAD = 50;
+      const TAIL = 50;
+      const lines =
+        allLines.length <= HEAD + TAIL
+          ? allLines
+          : [...allLines.slice(0, HEAD), ...allLines.slice(-TAIL)];
+
+      let customTitle = '';
+      for (const line of lines) {
+        try {
+          const data = JSON.parse(line) as { type?: string; customTitle?: string };
+          if (data.type === 'custom-title' && typeof data.customTitle === 'string') {
+            customTitle = data.customTitle;
+          }
+        } catch {
+          // skip unparseable lines
+        }
+      }
+
+      this.customTitleCache.set(cacheKey, customTitle);
+      return customTitle ? { ...entry, customTitle } : entry;
+    } catch {
+      this.customTitleCache.set(cacheKey, '');
+      return entry;
     }
   }
 

--- a/apps/desktop/src/modules/session/claude-session-reader.service.ts
+++ b/apps/desktop/src/modules/session/claude-session-reader.service.ts
@@ -50,6 +50,7 @@ export class ClaudeSessionReaderService implements OnModuleDestroy {
       watcher.close();
     }
     this.watchers.clear();
+    this.customTitleCache.clear();
   }
 
   /**
@@ -268,7 +269,90 @@ export class ClaudeSessionReaderService implements OnModuleDestroy {
   }
 
   /**
-   * Extract a ClaudeSessionEntry from a .jsonl file by reading the first few lines.
+   * Single-pass parse of all JSONL lines, returning every metadata field
+   * the reader cares about. Used by both `extractEntryFromJsonl` (for files
+   * not in the index) and `populateCustomTitle` (for index entries that
+   * need a customTitle/messageCount lookup).
+   *
+   * One pass over `allLines` — no head/tail window, so `/rename` events
+   * landing mid-session are never missed.
+   */
+  private parseJsonlMeta(allLines: string[]): {
+    sessionId?: string;
+    gitBranch: string;
+    firstTimestamp?: string;
+    firstPrompt: string;
+    isSidechain: boolean;
+    customTitle: string;
+    messageCount: number;
+  } {
+    let sessionId: string | undefined;
+    let gitBranch = '';
+    let firstTimestamp: string | undefined;
+    let firstPrompt = '';
+    let isSidechain = false;
+    let customTitle = '';
+    let messageCount = 0;
+
+    for (const line of allLines) {
+      let data: JsonlLineData;
+      try {
+        data = JSON.parse(line);
+      } catch {
+        this.logger.debug(`Skipping unparseable JSONL line: ${line.slice(0, 100)}`);
+        continue;
+      }
+
+      if (data.sessionId && !sessionId) {
+        sessionId = data.sessionId;
+      }
+      if (data.gitBranch && !gitBranch) {
+        gitBranch = data.gitBranch;
+      }
+      if (data.isSidechain) {
+        isSidechain = true;
+      }
+      if (data.timestamp && !firstTimestamp) {
+        firstTimestamp = data.timestamp;
+      }
+
+      // Track last custom-title entry — /rename can fire multiple times
+      if (data.type === 'custom-title' && typeof data.customTitle === 'string') {
+        customTitle = data.customTitle;
+      }
+
+      // Extract first user prompt
+      if (data.type === 'user' && data.message?.role === 'user' && !firstPrompt) {
+        const content = data.message.content;
+        if (typeof content === 'string') {
+          firstPrompt = content.slice(0, 200);
+        } else if (Array.isArray(content)) {
+          const textPart = content.find(p => p.type === 'text' && p.text);
+          if (textPart?.text) {
+            firstPrompt = textPart.text.slice(0, 200);
+          }
+        }
+      }
+
+      // Count user/assistant messages
+      if ((data.type === 'user' && data.message?.role === 'user') || data.type === 'assistant') {
+        messageCount++;
+      }
+    }
+
+    return {
+      sessionId,
+      gitBranch,
+      firstTimestamp,
+      firstPrompt,
+      isSidechain,
+      customTitle,
+      messageCount,
+    };
+  }
+
+  /**
+   * Extract a ClaudeSessionEntry from a .jsonl file via a single full-pass scan.
    * Returns null if the file can't be parsed.
    */
   private async extractEntryFromJsonl(
@@ -281,97 +365,27 @@ export class ClaudeSessionReaderService implements OnModuleDestroy {
     const sessionId = filename.replace('.jsonl', '');
 
     try {
-      // Read all lines but only keep the first 50 and last 50 to bound memory
       const content = await fs.promises.readFile(filePath, 'utf-8');
       const allLines = content.split(/\r?\n/).filter(l => l.trim());
-      const HEAD = 50;
-      const TAIL = 50;
-      const lines =
-        allLines.length <= HEAD + TAIL
-          ? allLines
-          : [...allLines.slice(0, HEAD), ...allLines.slice(-TAIL)];
-
-      let extractedSessionId: string | undefined;
-      let gitBranch = '';
-      let firstTimestamp: string | undefined;
-      let firstPrompt = '';
-      let isSidechain = false;
-      let customTitle = '';
-
-      for (const line of lines) {
-        try {
-          const data: JsonlLineData = JSON.parse(line);
-
-          // Extract session metadata from any line that has it
-          if (data.sessionId && !extractedSessionId) {
-            extractedSessionId = data.sessionId;
-          }
-          if (data.gitBranch && !gitBranch) {
-            gitBranch = data.gitBranch;
-          }
-          if (data.isSidechain) {
-            isSidechain = true;
-          }
-          if (data.timestamp && !firstTimestamp) {
-            firstTimestamp = data.timestamp;
-          }
-
-          // Track last custom-title entry — /rename can fire multiple times
-          if (data.type === 'custom-title' && typeof data.customTitle === 'string') {
-            customTitle = data.customTitle;
-          }
-
-          // Extract first user prompt
-          if (data.type === 'user' && data.message?.role === 'user' && !firstPrompt) {
-            const content = data.message.content;
-            if (typeof content === 'string') {
-              firstPrompt = content.slice(0, 200);
-            } else if (Array.isArray(content)) {
-              const textPart = content.find(p => p.type === 'text' && p.text);
-              if (textPart?.text) {
-                firstPrompt = textPart.text.slice(0, 200);
-              }
-            }
-          }
-        } catch {
-          this.logger.debug(`Skipping unparseable JSONL line: ${line.slice(0, 100)}`);
-        }
-      }
-
-      // Count messages across all lines (not just the head+tail window)
-      let messageCount = 0;
-      for (const line of allLines) {
-        try {
-          const data = JSON.parse(line) as JsonlLineData;
-          if (
-            (data.type === 'user' && data.message?.role === 'user') ||
-            data.type === 'assistant'
-          ) {
-            messageCount++;
-          }
-        } catch {
-          // skip unparseable lines
-        }
-      }
+      const meta = this.parseJsonlMeta(allLines);
 
       // Must have at least a session ID (from filename or content)
-      const finalSessionId = extractedSessionId ?? sessionId;
-
-      const created = firstTimestamp ?? new Date(mtimeMs).toISOString();
+      const finalSessionId = meta.sessionId ?? sessionId;
+      const created = meta.firstTimestamp ?? new Date(mtimeMs).toISOString();
 
       return {
         sessionId: finalSessionId,
         fullPath: filePath,
         fileMtime: mtimeMs,
-        firstPrompt: firstPrompt || 'No prompt',
+        firstPrompt: meta.firstPrompt || 'No prompt',
         summary: '', // Summary requires full file analysis; leave empty for scanned entries
-        messageCount,
+        messageCount: meta.messageCount,
         created,
         modified: new Date(mtimeMs).toISOString(), // Use file mtime as most accurate modified time
-        gitBranch,
+        gitBranch: meta.gitBranch,
         projectPath,
-        isSidechain,
-        ...(customTitle ? { customTitle } : {}),
+        isSidechain: meta.isSidechain,
+        ...(meta.customTitle ? { customTitle: meta.customTitle } : {}),
       };
     } catch (error) {
       const msg = extractErrorMessage(error);
@@ -383,6 +397,8 @@ export class ClaudeSessionReaderService implements OnModuleDestroy {
   /**
    * Populate customTitle for a sessions-index.json entry by scanning its JSONL.
    * Results are cached by sessionId+fileMtime to avoid repeated disk reads.
+   * Stale entries for the same session (older mtimes) are evicted before
+   * each write so the cache cannot grow without bound on repeated writes.
    */
   private async populateCustomTitle(
     entry: ClaudeSessionEntry,
@@ -398,28 +414,23 @@ export class ClaudeSessionReaderService implements OnModuleDestroy {
     try {
       const content = await fs.promises.readFile(filePath, 'utf-8');
       const allLines = content.split(/\r?\n/).filter(l => l.trim());
-      const HEAD = 50;
-      const TAIL = 50;
-      const lines =
-        allLines.length <= HEAD + TAIL
-          ? allLines
-          : [...allLines.slice(0, HEAD), ...allLines.slice(-TAIL)];
+      const { customTitle } = this.parseJsonlMeta(allLines);
 
-      let customTitle = '';
-      for (const line of lines) {
-        try {
-          const data = JSON.parse(line) as { type?: string; customTitle?: string };
-          if (data.type === 'custom-title' && typeof data.customTitle === 'string') {
-            customTitle = data.customTitle;
-          }
-        } catch {
-          // skip unparseable lines
+      const sessionPrefix = `${entry.sessionId}:`;
+      for (const k of this.customTitleCache.keys()) {
+        if (k.startsWith(sessionPrefix) && k !== cacheKey) {
+          this.customTitleCache.delete(k);
         }
       }
-
       this.customTitleCache.set(cacheKey, customTitle);
       return customTitle ? { ...entry, customTitle } : entry;
     } catch {
+      const sessionPrefix = `${entry.sessionId}:`;
+      for (const k of this.customTitleCache.keys()) {
+        if (k.startsWith(sessionPrefix) && k !== cacheKey) {
+          this.customTitleCache.delete(k);
+        }
+      }
       this.customTitleCache.set(cacheKey, '');
       return entry;
     }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -276,6 +276,7 @@ function App() {
               !hasContent && (
                 <div className="absolute inset-0 z-20">
                   <IdleLandingView
+                    projectPath={activeProjectPath}
                     onAddSession={handleAddSession}
                     onOpenLaunchModal={openLaunchModal}
                   />

--- a/apps/web/src/components/__tests__/shared-components.test.tsx
+++ b/apps/web/src/components/__tests__/shared-components.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import { StatusLegend, StatusDot } from '../shared/StatusLegend';
 import { ProgressBar } from '../shared/ProgressBar';
@@ -7,6 +7,47 @@ import { UsageCard } from '../shared/UsageCard';
 import { TaskBadge } from '../terminal/TaskBadge';
 import { ErrorBoundary } from '../shared/ErrorBoundary';
 import { IdleLandingView } from '../shared/IdleLandingView';
+import type { ClaudeSessionEntry } from '@omniscribe/shared';
+
+// ─── Mocks for IdleLandingView ────────────────────────────────────────────────
+
+const mockFetchHistory = vi.fn();
+const mockContinueLastSession = vi.fn().mockResolvedValue({ id: 's1' });
+const mockResumeSession = vi.fn().mockResolvedValue({ id: 's1' });
+const mockUpdateSession = vi.fn();
+
+// Mutable state object shared between the vi.mock factory and individual tests.
+// Tests mutate historyMockState.sessions to control what the store returns.
+const historyMockState = {
+  sessions: [] as ClaudeSessionEntry[],
+  isLoading: false,
+  error: null as string | null,
+  fetchHistory: mockFetchHistory,
+};
+
+vi.mock('@/stores/useSessionHistoryStore', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useSessionHistoryStore: vi.fn((selector: (s: any) => unknown) => selector(historyMockState)),
+}));
+
+vi.mock('@/stores/useSessionStore', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useSessionStore: vi.fn((selector: (s: any) => unknown) =>
+    selector({ updateSession: mockUpdateSession })
+  ),
+}));
+
+vi.mock('@/lib/session', () => ({
+  continueLastSession: (...args: unknown[]) => mockContinueLastSession(...args),
+  resumeSession: (...args: unknown[]) => mockResumeSession(...args),
+}));
+
+vi.mock('@/lib/platform', () => ({
+  IS_MAC: false,
+  IS_WINDOWS: true,
+  IS_LINUX: false,
+  IS_ELECTRON: false,
+}));
 
 // ─── StatusLegend ────────────────────────────────────────────────────────────
 
@@ -209,29 +250,117 @@ describe('ErrorBoundary', () => {
 
 // ─── IdleLandingView ─────────────────────────────────────────────────────────
 
+function makeMockSession(overrides: Partial<ClaudeSessionEntry> = {}): ClaudeSessionEntry {
+  return {
+    sessionId: `sess-${Math.random().toString(36).slice(2, 7)}`,
+    summary: 'Test summary',
+    firstPrompt: 'First prompt',
+    messageCount: 4,
+    gitBranch: 'main',
+    modified: '',
+    created: '',
+    projectPath: '/p',
+    fullPath: '',
+    fileMtime: 0,
+    isSidechain: false,
+    ...overrides,
+  };
+}
+
 describe('IdleLandingView', () => {
+  beforeEach(() => {
+    mockFetchHistory.mockClear();
+    mockContinueLastSession.mockClear();
+    mockResumeSession.mockClear();
+    mockUpdateSession.mockClear();
+    // Reset shared history state to empty
+    historyMockState.sessions = [];
+    historyMockState.isLoading = false;
+    historyMockState.error = null;
+  });
+
   it('renders without crashing with required props', () => {
-    const { container } = render(<IdleLandingView onAddSession={vi.fn()} />);
+    const { container } = render(<IdleLandingView projectPath={null} onAddSession={vi.fn()} />);
     expect(container).toBeTruthy();
   });
 
-  it('displays heading and description text', () => {
-    render(<IdleLandingView onAddSession={vi.fn()} />);
-    expect(screen.getByText('No Active Sessions')).toBeTruthy();
-    expect(
-      screen.getByText('Add sessions to start orchestrating your AI coding assistants')
-    ).toBeTruthy();
+  it('renders headline and subtitle copy', () => {
+    const { container } = render(<IdleLandingView projectPath={null} onAddSession={vi.fn()} />);
+    expect(container.textContent).toContain('Orchestrate a fleet of agents.');
+    expect(container.textContent).toContain(
+      'Run Claude Code, Codex, and plain shells side by side'
+    );
   });
 
-  it('displays keyboard shortcut hints', () => {
-    const { container } = render(<IdleLandingView onAddSession={vi.fn()} />);
-    expect(container.textContent).toContain('Shift+N');
-    expect(container.textContent).toContain('to add one');
+  it('renders Launch a fleet primary CTA', () => {
+    const { container } = render(<IdleLandingView projectPath={null} onAddSession={vi.fn()} />);
+    expect(container.textContent).toContain('Launch a fleet');
   });
 
-  it('renders the add session button with correct aria-label', () => {
-    render(<IdleLandingView onAddSession={vi.fn()} />);
-    const button = screen.getByRole('button', { name: 'Set up sessions' });
-    expect(button).toBeTruthy();
+  it('renders New session ghost CTA', () => {
+    const { container } = render(<IdleLandingView projectPath={null} onAddSession={vi.fn()} />);
+    expect(container.textContent).toContain('New session');
+  });
+
+  it('calls onOpenLaunchModal when primary CTA clicked and modal handler provided', () => {
+    const onOpenLaunchModal = vi.fn();
+    render(
+      <IdleLandingView
+        projectPath={null}
+        onAddSession={vi.fn()}
+        onOpenLaunchModal={onOpenLaunchModal}
+      />
+    );
+    const primaryBtn = screen.getByRole('button', { name: /launch a fleet/i });
+    fireEvent.click(primaryBtn);
+    expect(onOpenLaunchModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls fetchHistory with projectPath on mount when projectPath provided', () => {
+    render(<IdleLandingView projectPath="/some/project" onAddSession={vi.fn()} />);
+    expect(mockFetchHistory).toHaveBeenCalledWith('/some/project');
+  });
+
+  it('omits Recent panel when sessions list is empty', () => {
+    const { container } = render(
+      <IdleLandingView projectPath="/some/project" onAddSession={vi.fn()} />
+    );
+    expect(container.textContent).not.toContain('Resume last');
+  });
+
+  it('renders up to 3 Recent rows when sessions are present', () => {
+    historyMockState.sessions = [
+      makeMockSession({ sessionId: 'a', summary: 'Fix auth bug' }),
+      makeMockSession({ sessionId: 'b', summary: 'Add tests' }),
+      makeMockSession({ sessionId: 'c', summary: 'Refactor module' }),
+      makeMockSession({ sessionId: 'd', summary: 'Should not appear' }),
+    ];
+
+    const { container } = render(<IdleLandingView projectPath="/p" onAddSession={vi.fn()} />);
+    expect(container.textContent).toContain('Fix auth bug');
+    expect(container.textContent).toContain('Add tests');
+    expect(container.textContent).toContain('Refactor module');
+    expect(container.textContent).not.toContain('Should not appear');
+  });
+
+  it('calls resumeSession with entry when Recent row clicked', () => {
+    historyMockState.sessions = [
+      makeMockSession({
+        sessionId: 'sess-1',
+        summary: 'Fix login',
+        gitBranch: 'main',
+        projectPath: '/p',
+      }),
+    ];
+
+    render(<IdleLandingView projectPath="/p" onAddSession={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText('Resume session: Fix login'));
+    expect(mockResumeSession).toHaveBeenCalledWith('sess-1', '/p', 'main', 'Fix login');
+  });
+
+  it('Resume Last button is absent when no sessions (panel not rendered)', () => {
+    // historyMockState.sessions is [] from beforeEach — panel is hidden
+    render(<IdleLandingView projectPath="/p" onAddSession={vi.fn()} />);
+    expect(screen.queryByText('Resume last')).toBeNull();
   });
 });

--- a/apps/web/src/components/shared/IdleLandingView.tsx
+++ b/apps/web/src/components/shared/IdleLandingView.tsx
@@ -1,30 +1,83 @@
 import { cn } from '@/lib/utils';
-import { Plus } from 'lucide-react';
-import { useMemo } from 'react';
-import { OmniscribeAnimation } from './OmniscribeAnimation';
-import { getGreeting } from '@/lib/date-utils';
+import { Plus, Layers, GitBranch, MessageSquare, TerminalSquare, Sparkles } from 'lucide-react';
+import { useEffect, type ReactNode } from 'react';
 import { Button } from '@/components/ui/button';
 import { motion, useReducedMotion } from 'motion/react';
-import { animationVariants, transitions } from '@/lib/animations';
+import { transitions } from '@/lib/animations';
+import { useSessionHistoryStore } from '@/stores/useSessionHistoryStore';
+import { resumeSession, continueLastSession } from '@/lib/session';
+import { extractErrorMessage } from '@omniscribe/shared';
+import { useSessionStore } from '@/stores/useSessionStore';
+import { IS_MAC } from '@/lib/platform';
+import { toast } from 'sonner';
 
 interface IdleLandingViewProps {
+  projectPath: string | null;
   onAddSession: () => void;
   onOpenLaunchModal?: () => void;
   className?: string;
 }
 
 export function IdleLandingView({
+  projectPath,
   onAddSession,
   onOpenLaunchModal,
   className,
 }: IdleLandingViewProps) {
-  const greeting = useMemo(() => getGreeting(), []);
   const reduceMotion = useReducedMotion();
 
-  // Keyboard shortcuts (N, Shift+N) are handled globally by useAppKeyboardShortcuts
+  const sessions = useSessionHistoryStore(state => state.sessions);
+  const isLoading = useSessionHistoryStore(state => state.isLoading);
+  const error = useSessionHistoryStore(state => state.error);
+  const fetchHistory = useSessionHistoryStore(state => state.fetchHistory);
+  const updateSession = useSessionStore(state => state.updateSession);
 
-  // Primary CTA: open modal if available, otherwise add single session
-  const handlePrimaryCTA = onOpenLaunchModal ?? onAddSession;
+  useEffect(() => {
+    if (projectPath) {
+      fetchHistory(projectPath);
+    }
+  }, [projectPath, fetchHistory]);
+
+  const handleResumeLast = async () => {
+    if (!projectPath || sessions.length === 0) return;
+    try {
+      const session = await continueLastSession(projectPath);
+      if (session.terminalSessionId !== undefined) {
+        updateSession(session.id, { terminalSessionId: session.terminalSessionId });
+      }
+      toast.success('Continuing last session');
+    } catch (err) {
+      toast.error(extractErrorMessage(err, 'Failed to continue last session'));
+    }
+  };
+
+  const handleResumeEntry = async (entry: {
+    sessionId: string;
+    projectPath: string;
+    gitBranch: string;
+    summary: string;
+    firstPrompt: string;
+    customTitle?: string;
+  }) => {
+    if (!projectPath) return;
+    try {
+      const session = await resumeSession(
+        entry.sessionId,
+        projectPath,
+        entry.gitBranch,
+        entry.customTitle || entry.summary || entry.firstPrompt?.slice(0, 50)
+      );
+      if (session.terminalSessionId !== undefined) {
+        updateSession(session.id, { terminalSessionId: session.terminalSessionId });
+      }
+      toast.success('Session resumed successfully');
+    } catch (err) {
+      toast.error(extractErrorMessage(err, 'Failed to resume session'));
+    }
+  };
+
+  const recentSessions = sessions.slice(0, 3);
+  const hasRecent = isLoading || error || recentSessions.length > 0;
 
   return (
     <div
@@ -34,65 +87,233 @@ export function IdleLandingView({
         className
       )}
     >
-      {/* Card */}
+      {/* Ambient glow */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-60"
+        style={{
+          background:
+            'radial-gradient(ellipse at 50% 30%, var(--glow-1, transparent) 0%, transparent 55%)',
+        }}
+      />
+
       <motion.div
-        className={cn(
-          'relative flex flex-col items-center',
-          'px-12 py-10 rounded-2xl',
-          'bg-card',
-          'border border-border',
-          'shadow-sm'
-        )}
+        className="relative flex flex-col items-center w-full max-w-[560px] px-6"
         initial={reduceMotion ? false : { opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={reduceMotion ? transitions.instant : transitions.spring}
+        transition={reduceMotion ? { duration: 0 } : transitions.spring}
       >
-        {/* Greeting */}
-        <p className="text-sm text-foreground-secondary mb-6 text-center">{greeting}</p>
+        <IdleHero onAddSession={onAddSession} onOpenLaunchModal={onOpenLaunchModal} />
 
-        {/* Animated orchestration icon */}
-        <motion.div
-          className="mb-6"
-          initial={reduceMotion ? false : animationVariants.slideUp.initial}
-          animate={animationVariants.slideUp.animate}
-          transition={reduceMotion ? transitions.instant : transitions.spring}
-        >
-          <OmniscribeAnimation size={96} reduceMotion={!!reduceMotion} />
-        </motion.div>
-
-        {/* Text */}
-        <h2 className="text-lg font-medium text-foreground mb-2 text-center">No Active Sessions</h2>
-        <p className="text-sm text-foreground-secondary mb-8 text-center max-w-xs">
-          Add sessions to start orchestrating your AI coding assistants
-        </p>
-
-        {/* Add session button - opens modal as primary action */}
-        <Button
-          onClick={handlePrimaryCTA}
-          type="button"
-          size={'icon'}
-          aria-label="Set up sessions"
-          className="group"
-        >
-          <Plus
-            className="text-primary-foreground group-hover:rotate-90 transition-transform duration-200"
-            strokeWidth={2}
+        {hasRecent && (
+          <IdleRecentPanel
+            sessions={recentSessions}
+            isLoading={isLoading}
+            error={error}
+            projectPath={projectPath}
+            onResumeLast={handleResumeLast}
+            onResumeEntry={handleResumeEntry}
+            onRetry={() => projectPath && fetchHistory(projectPath)}
           />
-        </Button>
-
-        {/* Keyboard shortcut hint */}
-        <p className="mt-6 text-xs text-muted-foreground">
-          Press{' '}
-          <kbd className="px-1.5 py-0.5 rounded bg-muted border border-border font-mono text-foreground-secondary">
-            Shift+N
-          </kbd>{' '}
-          to set up sessions or{' '}
-          <kbd className="px-1.5 py-0.5 rounded bg-muted border border-border font-mono text-foreground-secondary">
-            N
-          </kbd>{' '}
-          to add one
-        </p>
+        )}
       </motion.div>
+    </div>
+  );
+}
+
+// ─── Sub-components ────────────────────────────────────────────────────────────
+
+interface IdleHeroProps {
+  onAddSession: () => void;
+  onOpenLaunchModal?: () => void;
+}
+
+function IdleHero({ onAddSession, onOpenLaunchModal }: IdleHeroProps) {
+  return (
+    <>
+      <IdleIconCluster />
+
+      <p className="text-2xs uppercase tracking-[0.18em] font-mono text-muted-foreground mb-3">
+        No active sessions
+      </p>
+
+      <h2 className="text-3xl font-semibold tracking-tight text-foreground text-center mb-3">
+        Orchestrate a fleet of agents.
+      </h2>
+
+      <p className="text-sm text-muted-foreground text-center max-w-[440px] mb-7 leading-relaxed">
+        Run Claude Code, Codex, and plain shells side by side — on the same branch or on parallel
+        worktrees.
+      </p>
+
+      <div className="flex items-center gap-3 mb-10">
+        <Button
+          onClick={onOpenLaunchModal ?? onAddSession}
+          type="button"
+          className="gap-2 px-4 h-10 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 font-medium"
+        >
+          <Layers size={16} />
+          Launch a fleet
+          <CtaKbd tone="onPrimary">⇧N</CtaKbd>
+        </Button>
+        <Button
+          variant="outline"
+          onClick={onAddSession}
+          type="button"
+          className="gap-2 px-4 h-10 rounded-lg border-border-glass bg-transparent hover:bg-card text-foreground"
+        >
+          <Plus size={16} />
+          New session
+          <CtaKbd tone="ghost">N</CtaKbd>
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function IdleIconCluster() {
+  const tileIcons = [TerminalSquare, GitBranch, Layers, Sparkles];
+  return (
+    <div className="grid grid-cols-2 gap-1.5 mb-7" aria-hidden>
+      {tileIcons.map((Icon, i) => (
+        <div
+          key={i}
+          className="flex items-center justify-center h-8 w-8 rounded-md bg-card/50 border border-border-glass/60 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.02)]"
+        >
+          <Icon size={14} strokeWidth={1.5} className="text-muted-foreground/40" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CtaKbd({ children, tone }: { children: ReactNode; tone: 'onPrimary' | 'ghost' }) {
+  return (
+    <kbd
+      className={cn(
+        'ml-1 inline-flex items-center px-1.5 h-5 rounded text-2xs font-mono',
+        tone === 'onPrimary'
+          ? 'bg-black/20 text-primary-foreground/85'
+          : 'bg-muted/60 text-muted-foreground border border-border-glass'
+      )}
+    >
+      {children}
+    </kbd>
+  );
+}
+
+interface IdleRecentPanelProps {
+  sessions: Array<{
+    sessionId: string;
+    summary: string;
+    firstPrompt: string;
+    gitBranch: string;
+    messageCount: number;
+    projectPath: string;
+    customTitle?: string;
+  }>;
+  isLoading: boolean;
+  error: string | null;
+  projectPath: string | null;
+  onResumeLast: () => void;
+  onResumeEntry: (entry: {
+    sessionId: string;
+    projectPath: string;
+    gitBranch: string;
+    summary: string;
+    firstPrompt: string;
+    customTitle?: string;
+  }) => void;
+  onRetry: () => void;
+}
+
+function IdleRecentPanel({
+  sessions,
+  isLoading,
+  error,
+  projectPath,
+  onResumeLast,
+  onResumeEntry,
+  onRetry,
+}: IdleRecentPanelProps) {
+  const modSymbol = IS_MAC ? '⌘' : 'Ctrl';
+
+  return (
+    <div className="w-full rounded-xl border border-border-glass bg-card/40 backdrop-blur-sm overflow-hidden">
+      {/* Header strip */}
+      <div className="flex items-center justify-between px-4 h-9 border-b border-border-glass/60">
+        <span className="text-2xs uppercase tracking-[0.18em] font-mono text-muted-foreground">
+          Recent
+        </span>
+        <button
+          type="button"
+          onClick={onResumeLast}
+          disabled={!sessions.length || isLoading}
+          aria-keyshortcuts={`${IS_MAC ? 'Meta' : 'Control'}+Shift+R`}
+          className="flex items-center gap-2 text-2xs uppercase tracking-[0.18em] font-mono text-muted-foreground hover:text-foreground disabled:opacity-40 transition-colors"
+        >
+          Resume last
+          <kbd className="inline-flex items-center px-1.5 h-5 rounded bg-muted/60 border border-border-glass font-mono text-2xs text-foreground-secondary">
+            {modSymbol}⇧R
+          </kbd>
+        </button>
+      </div>
+
+      {/* Body */}
+      {error ? (
+        <div className="px-4 py-3 text-2xs text-status-warning flex items-center gap-2">
+          Couldn't load recent sessions.{' '}
+          <button type="button" onClick={onRetry} className="underline hover:no-underline">
+            Retry
+          </button>
+        </div>
+      ) : isLoading && sessions.length === 0 ? (
+        <ul className="py-1">
+          {[0, 1, 2].map(i => (
+            <li key={i} className="px-4 py-2.5">
+              <div className="h-4 bg-muted/40 rounded animate-pulse w-3/4" />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <ul className="py-1">
+          {sessions.map(entry => {
+            const label =
+              entry.customTitle || entry.summary || entry.firstPrompt || 'Untitled session';
+            return (
+              <li key={entry.sessionId}>
+                <button
+                  type="button"
+                  aria-label={`Resume session: ${label}`}
+                  onClick={() =>
+                    onResumeEntry({
+                      sessionId: entry.sessionId,
+                      projectPath: projectPath ?? entry.projectPath,
+                      gitBranch: entry.gitBranch,
+                      summary: entry.summary,
+                      firstPrompt: entry.firstPrompt,
+                      customTitle: entry.customTitle,
+                    })
+                  }
+                  className="group w-full flex items-center gap-3 px-4 py-2.5 hover:bg-card/70 transition-colors"
+                >
+                  <span className="text-sm text-foreground truncate flex-1 text-left">{label}</span>
+                  {entry.gitBranch && (
+                    <span className="flex items-center gap-1 text-2xs font-mono text-muted-foreground shrink-0">
+                      <GitBranch size={11} />
+                      {entry.gitBranch}
+                    </span>
+                  )}
+                  <span className="flex items-center gap-1 text-2xs font-mono text-muted-foreground shrink-0 tabular-nums">
+                    <MessageSquare size={11} />
+                    {entry.messageCount}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/shared/IdleLandingView.tsx
+++ b/apps/web/src/components/shared/IdleLandingView.tsx
@@ -248,7 +248,7 @@ function IdleRecentPanel({
         <button
           type="button"
           onClick={onResumeLast}
-          disabled={!sessions.length || isLoading}
+          disabled={!projectPath || !sessions.length || isLoading}
           aria-keyshortcuts={`${IS_MAC ? 'Meta' : 'Control'}+Shift+R`}
           className="flex items-center gap-2 text-2xs uppercase tracking-[0.18em] font-mono text-muted-foreground hover:text-foreground disabled:opacity-40 transition-colors"
         >

--- a/apps/web/src/components/shared/SessionHistoryItem.tsx
+++ b/apps/web/src/components/shared/SessionHistoryItem.tsx
@@ -20,7 +20,7 @@ export const SessionHistoryItem = React.memo(function SessionHistoryItem({
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
           <p className="text-xs text-foreground-secondary truncate">
-            {entry.summary || entry.firstPrompt || 'Untitled session'}
+            {entry.customTitle || entry.summary || entry.firstPrompt || 'Untitled session'}
           </p>
           <div className="flex items-center gap-2 mt-1">
             {entry.gitBranch && (

--- a/apps/web/src/components/terminal/PersistentProjectGrid.tsx
+++ b/apps/web/src/components/terminal/PersistentProjectGrid.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { cn } from '@/lib/utils';
 import { useSessionStore } from '@/stores/useSessionStore';
+import { useSessionHistoryStore } from '@/stores/useSessionHistoryStore';
 import { useTerminalStore } from '@/stores/useTerminalStore';
 import { useAppUIStore } from '@/stores/useAppUIStore';
 import { mapToTerminalSessions } from '@/lib/session-mappers';
@@ -73,7 +74,7 @@ export function PersistentProjectGrid({
   const projectSessions = useSessionStore(
     useShallow(state => state.sessions.filter(s => s.projectPath === projectPath))
   );
-  const customTitles = useSessionStore(
+  const localCustomTitles = useSessionStore(
     useShallow(state => {
       const titles: Record<string, string> = {};
       for (const s of state.sessions) {
@@ -84,6 +85,32 @@ export function PersistentProjectGrid({
       return titles;
     })
   );
+
+  // Build a map from claudeSessionId -> customTitle for history entries
+  const claudeCustomTitlesByClaudeId = useSessionHistoryStore(
+    useShallow(state => {
+      const map: Record<string, string> = {};
+      for (const entry of state.sessions) {
+        if (entry.customTitle) {
+          map[entry.sessionId] = entry.customTitle;
+        }
+      }
+      return map;
+    })
+  );
+
+  // Merge: Omniscribe-local > Claude customTitle > nothing (downstream fallback handles rest)
+  const customTitles = useMemo(() => {
+    const titles: Record<string, string> = {};
+    for (const s of projectSessions) {
+      if (localCustomTitles[s.id]) {
+        titles[s.id] = localCustomTitles[s.id];
+      } else if (s.claudeSessionId && claudeCustomTitlesByClaudeId[s.claudeSessionId]) {
+        titles[s.id] = claudeCustomTitlesByClaudeId[s.claudeSessionId];
+      }
+    }
+    return titles;
+  }, [projectSessions, localCustomTitles, claudeCustomTitlesByClaudeId]);
   const sessionOrder = useTerminalStore(state => state.sessionOrder);
   const setSessionOrder = useTerminalStore(state => state.setSessionOrder);
 
@@ -172,6 +199,7 @@ export function PersistentProjectGrid({
           preLaunchSlots={effectivePreLaunchSlots}
           launchingSlotIds={isActive ? launchingSlotIds : undefined}
           branches={effectiveBranches}
+          projectPath={projectPath}
           worktreeMode={isActive ? worktreeMode : undefined}
           focusedSessionId={focusedSessionId}
           onFocusSession={handleFocusSession}

--- a/apps/web/src/components/terminal/TerminalGrid.tsx
+++ b/apps/web/src/components/terminal/TerminalGrid.tsx
@@ -24,6 +24,8 @@ interface TerminalGridProps {
   preLaunchSlots: PreLaunchSlot[];
   launchingSlotIds?: Set<string>;
   branches: Branch[];
+  /** Project path — forwarded to IdleLandingView for the Recent panel */
+  projectPath?: string | null;
   /** Whether Claude CLI is available (controls Claude mode option) */
   claudeAvailable?: boolean;
   /** Worktree mode — hides branch selector when 'never' */
@@ -49,6 +51,7 @@ export function TerminalGrid({
   preLaunchSlots,
   launchingSlotIds,
   branches,
+  projectPath,
   claudeAvailable,
   worktreeMode,
   isActive = true,
@@ -113,6 +116,7 @@ export function TerminalGrid({
   if (sessionCount === 0 && preLaunchSlots.length === 0) {
     return (
       <IdleLandingView
+        projectPath={projectPath ?? null}
         onAddSession={onAddSlot}
         onOpenLaunchModal={onOpenLaunchModal}
         className={className}

--- a/apps/web/src/hooks/useAppKeyboardShortcuts.ts
+++ b/apps/web/src/hooks/useAppKeyboardShortcuts.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { PRELAUNCH_SHORTCUT_KEYS } from '@/lib/prelaunch-shortcuts';
 import { useAppUIStore } from '@/stores/useAppUIStore';
+import { continueLastSession } from '@/lib/session';
 import type { PreLaunchSlot } from '@/components/terminal/TerminalGrid';
 
 interface UseAppKeyboardShortcutsParams {
@@ -87,6 +88,19 @@ export function useAppKeyboardShortcuts({
       if (isMod && e.shiftKey && key === 'h') {
         e.preventDefault();
         useAppUIStore.getState().toggleHistory();
+        return;
+      }
+
+      // Cmd/Ctrl + Shift + R - Resume last session (idle view convenience)
+      if (isMod && e.shiftKey && key === 'r') {
+        const projectPath = activeProjectPathRef.current;
+        if (projectPath && !hasActiveSessionsRef.current) {
+          e.preventDefault();
+          continueLastSession(projectPath).catch(() => {
+            // error is surfaced via toast inside IdleLandingView's handler;
+            // swallow here so an unhandled rejection doesn't surface in console
+          });
+        }
         return;
       }
 

--- a/apps/web/src/hooks/useAppKeyboardShortcuts.ts
+++ b/apps/web/src/hooks/useAppKeyboardShortcuts.ts
@@ -1,4 +1,6 @@
 import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+import { extractErrorMessage } from '@omniscribe/shared';
 import { PRELAUNCH_SHORTCUT_KEYS } from '@/lib/prelaunch-shortcuts';
 import { useAppUIStore } from '@/stores/useAppUIStore';
 import { continueLastSession } from '@/lib/session';
@@ -93,12 +95,11 @@ export function useAppKeyboardShortcuts({
 
       // Cmd/Ctrl + Shift + R - Resume last session (idle view convenience)
       if (isMod && e.shiftKey && key === 'r') {
+        e.preventDefault();
         const projectPath = activeProjectPathRef.current;
         if (projectPath && !hasActiveSessionsRef.current) {
-          e.preventDefault();
-          continueLastSession(projectPath).catch(() => {
-            // error is surfaced via toast inside IdleLandingView's handler;
-            // swallow here so an unhandled rejection doesn't surface in console
+          continueLastSession(projectPath).catch(err => {
+            toast.error(extractErrorMessage(err, 'Failed to resume last session'));
           });
         }
         return;

--- a/apps/web/src/hooks/useSessionHistory.ts
+++ b/apps/web/src/hooks/useSessionHistory.ts
@@ -80,6 +80,7 @@ export function useSessionHistory({
       const lower = debouncedSearch.toLowerCase();
       result = result.filter(
         s =>
+          (s.customTitle && s.customTitle.toLowerCase().includes(lower)) ||
           (s.summary && s.summary.toLowerCase().includes(lower)) ||
           (s.firstPrompt && s.firstPrompt.toLowerCase().includes(lower))
       );
@@ -106,7 +107,7 @@ export function useSessionHistory({
           entry.sessionId,
           projectPath,
           entry.gitBranch,
-          entry.summary || entry.firstPrompt?.slice(0, 50)
+          entry.customTitle || entry.summary || entry.firstPrompt?.slice(0, 50)
         );
         if (session.terminalSessionId !== undefined) {
           updateSession(session.id, { terminalSessionId: session.terminalSessionId });
@@ -129,7 +130,7 @@ export function useSessionHistory({
           entry.sessionId,
           projectPath,
           entry.gitBranch,
-          `Fork: ${(entry.summary || entry.firstPrompt || 'session').slice(0, 40)}`
+          `Fork: ${(entry.customTitle || entry.summary || entry.firstPrompt || 'session').slice(0, 40)}`
         );
         if (session.terminalSessionId !== undefined) {
           updateSession(session.id, { terminalSessionId: session.terminalSessionId });

--- a/apps/web/src/stores/useSessionHistoryStore.ts
+++ b/apps/web/src/stores/useSessionHistoryStore.ts
@@ -89,7 +89,13 @@ export const useSessionHistoryStore = create<SessionHistoryStore>()(
 
         fetchHistory: (projectPath: string) => {
           logger.debug('fetchHistory', projectPath);
-          set({ isLoading: true }, undefined, 'sessionHistory/fetchHistory');
+          // Reset sessions synchronously so a project switch doesn't briefly
+          // render the previous project's history while the new fetch is in flight.
+          set(
+            { isLoading: true, sessions: [], error: null },
+            undefined,
+            'sessionHistory/fetchHistory'
+          );
 
           const timeout = setTimeout(() => {
             set(

--- a/packages/plugins/provider-claude/src/__tests__/session-reader.service.spec.ts
+++ b/packages/plugins/provider-claude/src/__tests__/session-reader.service.spec.ts
@@ -192,6 +192,7 @@ describe('ClaudeSessionReaderService', () => {
         sessionId: 'indexed-session',
         modified: '2025-01-01T00:00:00Z',
       });
+      // Call 1: sessions-index.json
       mockFsPromises.readFile.mockResolvedValueOnce(
         JSON.stringify({ version: 1, entries: [indexedEntry] })
       );
@@ -203,13 +204,16 @@ describe('ClaudeSessionReaderService', () => {
 
       mockFsPromises.stat.mockResolvedValueOnce({ mtimeMs: 3000 });
 
-      mockLines.push(
+      // Call 2: extractEntryFromJsonl for new-session.jsonl
+      mockFsPromises.readFile.mockResolvedValueOnce(
         JSON.stringify({
           sessionId: 'new-session',
           timestamp: '2025-01-10T00:00:00Z',
           gitBranch: 'feature/test',
         })
       );
+      // Call 3: populateCustomTitle for indexed-session (no customTitle found)
+      mockFsPromises.readFile.mockResolvedValueOnce('');
 
       const entries = await service.readSessionsIndex('/project');
 
@@ -366,23 +370,30 @@ describe('ClaudeSessionReaderService', () => {
   // extractEntryFromJsonl (tested indirectly)
   // ==================================================================
   describe('extractEntryFromJsonl (via readSessionsIndex)', () => {
-    function setupSingleJsonlScan() {
+    /**
+     * Sets up a scan of a single JSONL file with the given lines as content.
+     * Call this AFTER setting up the JSONL lines so the readFile mock order is correct:
+     *   1. sessions-index.json → EMPTY_INDEX
+     *   2. test-session.jsonl  → provided lines joined by newline
+     */
+    function setupSingleJsonlScan(jsonlLines: string[] = []) {
       mockFsPromises.readFile.mockResolvedValueOnce(EMPTY_INDEX);
       mockFsPromises.readdir.mockResolvedValueOnce([
         { name: 'test-session.jsonl', isFile: () => true },
       ]);
       mockFsPromises.stat.mockResolvedValueOnce({ mtimeMs: 5000 });
+      mockFsPromises.readFile.mockResolvedValueOnce(jsonlLines.join('\n'));
     }
 
     it('should extract sessionId, gitBranch, and timestamp from jsonl lines', async () => {
-      mockLines.push(
+      const lines = [
         JSON.stringify({
           sessionId: 'extracted-id',
           gitBranch: 'feature/branch',
           timestamp: '2025-06-01T12:00:00Z',
-        })
-      );
-      setupSingleJsonlScan();
+        }),
+      ];
+      setupSingleJsonlScan(lines);
 
       const entries = await service.readSessionsIndex('/project');
 
@@ -393,14 +404,14 @@ describe('ClaudeSessionReaderService', () => {
     });
 
     it('should extract first user prompt from string content', async () => {
-      mockLines.push(
+      const lines = [
         JSON.stringify({ sessionId: 'sess-1', timestamp: '2025-01-01T00:00:00Z' }),
         JSON.stringify({
           type: 'user',
           message: { role: 'user', content: 'Fix the login bug' },
-        })
-      );
-      setupSingleJsonlScan();
+        }),
+      ];
+      setupSingleJsonlScan(lines);
 
       const entries = await service.readSessionsIndex('/project');
 
@@ -409,7 +420,7 @@ describe('ClaudeSessionReaderService', () => {
     });
 
     it('should extract first user prompt from array content', async () => {
-      mockLines.push(
+      const lines = [
         JSON.stringify({ sessionId: 'sess-1', timestamp: '2025-01-01T00:00:00Z' }),
         JSON.stringify({
           type: 'user',
@@ -417,9 +428,9 @@ describe('ClaudeSessionReaderService', () => {
             role: 'user',
             content: [{ type: 'text', text: 'Help me refactor' }],
           },
-        })
-      );
-      setupSingleJsonlScan();
+        }),
+      ];
+      setupSingleJsonlScan(lines);
 
       const entries = await service.readSessionsIndex('/project');
 
@@ -428,14 +439,14 @@ describe('ClaudeSessionReaderService', () => {
     });
 
     it('should detect sidechain sessions and filter them out', async () => {
-      mockLines.push(
+      const lines = [
         JSON.stringify({
           sessionId: 'sidechain-sess',
           timestamp: '2025-01-01T00:00:00Z',
           isSidechain: true,
-        })
-      );
-      setupSingleJsonlScan();
+        }),
+      ];
+      setupSingleJsonlScan(lines);
 
       const entries = await service.readSessionsIndex('/project');
 
@@ -443,8 +454,8 @@ describe('ClaudeSessionReaderService', () => {
     });
 
     it('should use filename as sessionId when content has no sessionId', async () => {
-      mockLines.push(JSON.stringify({ timestamp: '2025-01-01T00:00:00Z' }));
-      setupSingleJsonlScan();
+      const lines = [JSON.stringify({ timestamp: '2025-01-01T00:00:00Z' })];
+      setupSingleJsonlScan(lines);
 
       const entries = await service.readSessionsIndex('/project');
 
@@ -453,8 +464,8 @@ describe('ClaudeSessionReaderService', () => {
     });
 
     it('should use file mtime as created date when no timestamp in content', async () => {
-      mockLines.push(JSON.stringify({ sessionId: 'no-ts-session' }));
-      setupSingleJsonlScan();
+      const lines = [JSON.stringify({ sessionId: 'no-ts-session' })];
+      setupSingleJsonlScan(lines);
 
       const entries = await service.readSessionsIndex('/project');
 
@@ -463,8 +474,8 @@ describe('ClaudeSessionReaderService', () => {
     });
 
     it('should default firstPrompt to "No prompt" when none found', async () => {
-      mockLines.push(JSON.stringify({ sessionId: 'no-prompt' }));
-      setupSingleJsonlScan();
+      const lines = [JSON.stringify({ sessionId: 'no-prompt' })];
+      setupSingleJsonlScan(lines);
 
       const entries = await service.readSessionsIndex('/project');
 
@@ -473,11 +484,11 @@ describe('ClaudeSessionReaderService', () => {
     });
 
     it('should skip unparseable lines without failing', async () => {
-      mockLines.push(
+      const lines = [
         'not json at all',
-        JSON.stringify({ sessionId: 'good-session', timestamp: '2025-01-01T00:00:00Z' })
-      );
-      setupSingleJsonlScan();
+        JSON.stringify({ sessionId: 'good-session', timestamp: '2025-01-01T00:00:00Z' }),
+      ];
+      setupSingleJsonlScan(lines);
 
       const entries = await service.readSessionsIndex('/project');
 
@@ -485,11 +496,9 @@ describe('ClaudeSessionReaderService', () => {
       expect(entries[0].sessionId).toBe('good-session');
     });
 
-    it('should only read first 20 lines', async () => {
-      for (let i = 0; i < 25; i++) {
-        mockLines.push(JSON.stringify({ line: i }));
-      }
-      setupSingleJsonlScan();
+    it('should handle files with many lines and still return an entry', async () => {
+      const lines = Array.from({ length: 25 }, (_, i) => JSON.stringify({ line: i }));
+      setupSingleJsonlScan(lines);
 
       const entries = await service.readSessionsIndex('/project');
 
@@ -499,18 +508,57 @@ describe('ClaudeSessionReaderService', () => {
 
     it('should truncate firstPrompt to 200 characters', async () => {
       const longPrompt = 'A'.repeat(300);
-      mockLines.push(
+      const lines = [
         JSON.stringify({ sessionId: 'sess-1', timestamp: '2025-01-01T00:00:00Z' }),
         JSON.stringify({
           type: 'user',
           message: { role: 'user', content: longPrompt },
-        })
-      );
-      setupSingleJsonlScan();
+        }),
+      ];
+      setupSingleJsonlScan(lines);
 
       const entries = await service.readSessionsIndex('/project');
 
       expect(entries[0].firstPrompt).toHaveLength(200);
+    });
+
+    it('should compute messageCount from user and assistant lines', async () => {
+      const lines = [
+        JSON.stringify({ sessionId: 'msg-count-session', timestamp: '2025-01-01T00:00:00Z' }),
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'First prompt' } }),
+        JSON.stringify({
+          type: 'assistant',
+          message: { role: 'assistant', content: 'Response 1' },
+        }),
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'Follow-up' } }),
+        JSON.stringify({
+          type: 'assistant',
+          message: { role: 'assistant', content: 'Response 2' },
+        }),
+        // tool_result user line — should NOT be counted (no role check for these)
+        JSON.stringify({ type: 'user', message: { role: 'tool', content: 'tool result' } }),
+        // system line — should not be counted
+        JSON.stringify({ type: 'system', message: { content: 'system prompt' } }),
+      ];
+      setupSingleJsonlScan(lines);
+
+      const entries = await service.readSessionsIndex('/project');
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].messageCount).toBe(4);
+    });
+
+    it('should return messageCount 0 when no user or assistant lines present', async () => {
+      const lines = [
+        JSON.stringify({ sessionId: 'no-msgs', timestamp: '2025-01-01T00:00:00Z' }),
+        JSON.stringify({ type: 'system', message: { content: 'setup' } }),
+      ];
+      setupSingleJsonlScan(lines);
+
+      const entries = await service.readSessionsIndex('/project');
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].messageCount).toBe(0);
     });
   });
 

--- a/packages/plugins/provider-claude/src/services/session-reader.service.ts
+++ b/packages/plugins/provider-claude/src/services/session-reader.service.ts
@@ -63,6 +63,7 @@ export class ClaudeSessionReaderService {
       watcher.close();
     }
     this.watchers.clear();
+    this.customTitleCache.clear();
   }
 
   /**
@@ -228,7 +229,7 @@ export class ClaudeSessionReaderService {
     return entries.map(entry => ({
       sessionId: entry.sessionId,
       projectPath: entry.projectPath,
-      summary: entry.customTitle || entry.firstPrompt || entry.summary || undefined,
+      summary: entry.customTitle || entry.summary || entry.firstPrompt || undefined,
       messageCount: entry.messageCount || undefined,
       created: entry.created,
       modified: entry.modified,
@@ -307,7 +308,90 @@ export class ClaudeSessionReaderService {
   }
 
   /**
-   * Extract a ClaudeSessionEntry from a .jsonl file by reading the first few lines.
+   * Single-pass parse of all JSONL lines, returning every metadata field
+   * the reader cares about. Used by both `extractEntryFromJsonl` (for files
+   * not in the index) and `populateCustomTitle` (for index entries that
+   * need a customTitle/messageCount lookup).
+   *
+   * One pass over `allLines` — no head/tail window, so `/rename` events
+   * landing mid-session are never missed.
+   */
+  private parseJsonlMeta(allLines: string[]): {
+    sessionId?: string;
+    gitBranch: string;
+    firstTimestamp?: string;
+    firstPrompt: string;
+    isSidechain: boolean;
+    customTitle: string;
+    messageCount: number;
+  } {
+    let sessionId: string | undefined;
+    let gitBranch = '';
+    let firstTimestamp: string | undefined;
+    let firstPrompt = '';
+    let isSidechain = false;
+    let customTitle = '';
+    let messageCount = 0;
+
+    for (const line of allLines) {
+      let data: JsonlLineData;
+      try {
+        data = JSON.parse(line);
+      } catch {
+        this.logger.debug(`Skipping unparseable JSONL line: ${line.slice(0, 100)}`);
+        continue;
+      }
+
+      if (data.sessionId && !sessionId) {
+        sessionId = data.sessionId;
+      }
+      if (data.gitBranch && !gitBranch) {
+        gitBranch = data.gitBranch;
+      }
+      if (data.isSidechain) {
+        isSidechain = true;
+      }
+      if (data.timestamp && !firstTimestamp) {
+        firstTimestamp = data.timestamp;
+      }
+
+      // Track last custom-title entry — /rename can fire multiple times
+      if (data.type === 'custom-title' && typeof data.customTitle === 'string') {
+        customTitle = data.customTitle;
+      }
+
+      // Extract first user prompt
+      if (data.type === 'user' && data.message?.role === 'user' && !firstPrompt) {
+        const content = data.message.content;
+        if (typeof content === 'string') {
+          firstPrompt = content.slice(0, 200);
+        } else if (Array.isArray(content)) {
+          const textPart = content.find(p => p.type === 'text' && p.text);
+          if (textPart?.text) {
+            firstPrompt = textPart.text.slice(0, 200);
+          }
+        }
+      }
+
+      // Count user/assistant messages
+      if ((data.type === 'user' && data.message?.role === 'user') || data.type === 'assistant') {
+        messageCount++;
+      }
+    }
+
+    return {
+      sessionId,
+      gitBranch,
+      firstTimestamp,
+      firstPrompt,
+      isSidechain,
+      customTitle,
+      messageCount,
+    };
+  }
+
+  /**
+   * Extract a ClaudeSessionEntry from a .jsonl file via a single full-pass scan.
    * Returns null if the file can't be parsed.
    */
   private async extractEntryFromJsonl(
@@ -320,97 +404,27 @@ export class ClaudeSessionReaderService {
     const sessionId = filename.replace('.jsonl', '');
 
     try {
-      // Read all lines but only keep the first 50 and last 50 to bound memory
       const content = await fs.promises.readFile(filePath, 'utf-8');
       const allLines = content.split(/\r?\n/).filter(l => l.trim());
-      const HEAD = 50;
-      const TAIL = 50;
-      const lines =
-        allLines.length <= HEAD + TAIL
-          ? allLines
-          : [...allLines.slice(0, HEAD), ...allLines.slice(-TAIL)];
-
-      let extractedSessionId: string | undefined;
-      let gitBranch = '';
-      let firstTimestamp: string | undefined;
-      let firstPrompt = '';
-      let isSidechain = false;
-      let customTitle = '';
-
-      for (const line of lines) {
-        try {
-          const data: JsonlLineData = JSON.parse(line);
-
-          // Extract session metadata from any line that has it
-          if (data.sessionId && !extractedSessionId) {
-            extractedSessionId = data.sessionId;
-          }
-          if (data.gitBranch && !gitBranch) {
-            gitBranch = data.gitBranch;
-          }
-          if (data.isSidechain) {
-            isSidechain = true;
-          }
-          if (data.timestamp && !firstTimestamp) {
-            firstTimestamp = data.timestamp;
-          }
-
-          // Track last custom-title entry — /rename can fire multiple times
-          if (data.type === 'custom-title' && typeof data.customTitle === 'string') {
-            customTitle = data.customTitle;
-          }
-
-          // Extract first user prompt
-          if (data.type === 'user' && data.message?.role === 'user' && !firstPrompt) {
-            const content = data.message.content;
-            if (typeof content === 'string') {
-              firstPrompt = content.slice(0, 200);
-            } else if (Array.isArray(content)) {
-              const textPart = content.find(p => p.type === 'text' && p.text);
-              if (textPart?.text) {
-                firstPrompt = textPart.text.slice(0, 200);
-              }
-            }
-          }
-        } catch {
-          this.logger.debug(`Skipping unparseable JSONL line: ${line.slice(0, 100)}`);
-        }
-      }
-
-      // Count messages across all lines (not just the head+tail window)
-      let messageCount = 0;
-      for (const line of allLines) {
-        try {
-          const data = JSON.parse(line) as JsonlLineData;
-          if (
-            (data.type === 'user' && data.message?.role === 'user') ||
-            data.type === 'assistant'
-          ) {
-            messageCount++;
-          }
-        } catch {
-          // skip unparseable lines
-        }
-      }
+      const meta = this.parseJsonlMeta(allLines);
 
       // Must have at least a session ID (from filename or content)
-      const finalSessionId = extractedSessionId ?? sessionId;
-
-      const created = firstTimestamp ?? new Date(mtimeMs).toISOString();
+      const finalSessionId = meta.sessionId ?? sessionId;
+      const created = meta.firstTimestamp ?? new Date(mtimeMs).toISOString();
 
       return {
         sessionId: finalSessionId,
         fullPath: filePath,
         fileMtime: mtimeMs,
-        firstPrompt: firstPrompt || 'No prompt',
+        firstPrompt: meta.firstPrompt || 'No prompt',
         summary: '', // Summary requires full file analysis; leave empty for scanned entries
-        messageCount,
+        messageCount: meta.messageCount,
         created,
         modified: new Date(mtimeMs).toISOString(), // Use file mtime as most accurate modified time
-        gitBranch,
+        gitBranch: meta.gitBranch,
         projectPath,
-        isSidechain,
-        ...(customTitle ? { customTitle } : {}),
+        isSidechain: meta.isSidechain,
+        ...(meta.customTitle ? { customTitle: meta.customTitle } : {}),
       };
     } catch (error) {
       const msg = extractErrorMessage(error);
@@ -437,28 +451,25 @@ export class ClaudeSessionReaderService {
     try {
       const content = await fs.promises.readFile(filePath, 'utf-8');
       const allLines = content.split(/\r?\n/).filter(l => l.trim());
-      const HEAD = 50;
-      const TAIL = 50;
-      const lines =
-        allLines.length <= HEAD + TAIL
-          ? allLines
-          : [...allLines.slice(0, HEAD), ...allLines.slice(-TAIL)];
+      const { customTitle } = this.parseJsonlMeta(allLines);
 
-      let customTitle = '';
-      for (const line of lines) {
-        try {
-          const data = JSON.parse(line) as { type?: string; customTitle?: string };
-          if (data.type === 'custom-title' && typeof data.customTitle === 'string') {
-            customTitle = data.customTitle;
-          }
-        } catch {
-          // skip unparseable lines
+      // Evict any prior cache entries for this session at older mtimes
+      // so the map can't grow without bound on repeated writes.
+      const sessionPrefix = `${entry.sessionId}:`;
+      for (const k of this.customTitleCache.keys()) {
+        if (k.startsWith(sessionPrefix) && k !== cacheKey) {
+          this.customTitleCache.delete(k);
         }
       }
-
       this.customTitleCache.set(cacheKey, customTitle);
       return customTitle ? { ...entry, customTitle } : entry;
     } catch {
+      const sessionPrefix = `${entry.sessionId}:`;
+      for (const k of this.customTitleCache.keys()) {
+        if (k.startsWith(sessionPrefix) && k !== cacheKey) {
+          this.customTitleCache.delete(k);
+        }
+      }
       this.customTitleCache.set(cacheKey, '');
       return entry;
     }

--- a/packages/plugins/provider-claude/src/services/session-reader.service.ts
+++ b/packages/plugins/provider-claude/src/services/session-reader.service.ts
@@ -11,7 +11,6 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as readline from 'readline';
 import {
   ClaudeSessionEntry,
   ClaudeSessionsIndex,
@@ -31,6 +30,7 @@ interface JsonlLineData {
   type?: string;
   isSidechain?: boolean;
   cwd?: string;
+  customTitle?: string;
   message?: { role?: string; content?: string | Array<{ type: string; text?: string }> };
 }
 
@@ -49,6 +49,9 @@ export class ClaudeSessionReaderService {
 
   /** Active file watchers keyed by project path, for cleanup on destroy */
   private watchers = new Map<string, fs.FSWatcher>();
+
+  /** Cache of customTitle keyed by "<sessionId>:<fileMtime>" to avoid re-reads */
+  private customTitleCache = new Map<string, string>();
 
   /**
    * Clean up all resources (file watchers).
@@ -99,8 +102,14 @@ export class ClaudeSessionReaderService {
       this.logger.warn(`Failed to scan .jsonl files: ${errorMessage}`);
     }
 
-    // Step 3: Merge and return
-    const allEntries = [...indexEntries, ...scannedEntries];
+    // Step 3: Merge — scanned entries already have customTitle from JSONL scan.
+    // For index entries (which come from sessions-index.json and never carry customTitle),
+    // do a lazy single-pass JSONL read to populate the field.
+    const populatedIndexEntries = await Promise.all(
+      indexEntries.map(entry => this.populateCustomTitle(entry, sessionsDir))
+    );
+
+    const allEntries = [...populatedIndexEntries, ...scannedEntries];
     return this.filterAndSort(allEntries);
   }
 
@@ -219,7 +228,7 @@ export class ClaudeSessionReaderService {
     return entries.map(entry => ({
       sessionId: entry.sessionId,
       projectPath: entry.projectPath,
-      summary: entry.firstPrompt || entry.summary || undefined,
+      summary: entry.customTitle || entry.firstPrompt || entry.summary || undefined,
       messageCount: entry.messageCount || undefined,
       created: entry.created,
       modified: entry.modified,
@@ -228,6 +237,7 @@ export class ClaudeSessionReaderService {
         gitBranch: entry.gitBranch,
         isSidechain: entry.isSidechain,
         fileMtime: entry.fileMtime,
+        customTitle: entry.customTitle,
       },
     }));
   }
@@ -310,22 +320,24 @@ export class ClaudeSessionReaderService {
     const sessionId = filename.replace('.jsonl', '');
 
     try {
-      const fileStream = fs.createReadStream(filePath, { encoding: 'utf-8' });
-      const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+      // Read all lines but only keep the first 50 and last 50 to bound memory
+      const content = await fs.promises.readFile(filePath, 'utf-8');
+      const allLines = content.split(/\r?\n/).filter(l => l.trim());
+      const HEAD = 50;
+      const TAIL = 50;
+      const lines =
+        allLines.length <= HEAD + TAIL
+          ? allLines
+          : [...allLines.slice(0, HEAD), ...allLines.slice(-TAIL)];
 
-      let lineCount = 0;
       let extractedSessionId: string | undefined;
       let gitBranch = '';
       let firstTimestamp: string | undefined;
       let firstPrompt = '';
       let isSidechain = false;
+      let customTitle = '';
 
-      for await (const line of rl) {
-        if (lineCount >= 20) break; // Only read first 20 lines
-        lineCount++;
-
-        if (!line.trim()) continue;
-
+      for (const line of lines) {
         try {
           const data: JsonlLineData = JSON.parse(line);
 
@@ -341,6 +353,11 @@ export class ClaudeSessionReaderService {
           }
           if (data.timestamp && !firstTimestamp) {
             firstTimestamp = data.timestamp;
+          }
+
+          // Track last custom-title entry — /rename can fire multiple times
+          if (data.type === 'custom-title' && typeof data.customTitle === 'string') {
+            customTitle = data.customTitle;
           }
 
           // Extract first user prompt
@@ -360,7 +377,21 @@ export class ClaudeSessionReaderService {
         }
       }
 
-      rl.close();
+      // Count messages across all lines (not just the head+tail window)
+      let messageCount = 0;
+      for (const line of allLines) {
+        try {
+          const data = JSON.parse(line) as JsonlLineData;
+          if (
+            (data.type === 'user' && data.message?.role === 'user') ||
+            data.type === 'assistant'
+          ) {
+            messageCount++;
+          }
+        } catch {
+          // skip unparseable lines
+        }
+      }
 
       // Must have at least a session ID (from filename or content)
       const finalSessionId = extractedSessionId ?? sessionId;
@@ -373,17 +404,63 @@ export class ClaudeSessionReaderService {
         fileMtime: mtimeMs,
         firstPrompt: firstPrompt || 'No prompt',
         summary: '', // Summary requires full file analysis; leave empty for scanned entries
-        messageCount: 0, // Unknown without full scan
+        messageCount,
         created,
         modified: new Date(mtimeMs).toISOString(), // Use file mtime as most accurate modified time
         gitBranch,
         projectPath,
         isSidechain,
+        ...(customTitle ? { customTitle } : {}),
       };
     } catch (error) {
       const msg = extractErrorMessage(error);
       this.logger.debug(`Failed to extract entry from ${filename}: ${msg}`);
       return null;
+    }
+  }
+
+  /**
+   * Populate customTitle for a sessions-index.json entry by scanning its JSONL.
+   * Results are cached by sessionId+fileMtime to avoid repeated disk reads.
+   */
+  private async populateCustomTitle(
+    entry: ClaudeSessionEntry,
+    sessionsDir: string
+  ): Promise<ClaudeSessionEntry> {
+    const cacheKey = `${entry.sessionId}:${entry.fileMtime}`;
+    if (this.customTitleCache.has(cacheKey)) {
+      const cached = this.customTitleCache.get(cacheKey)!;
+      return cached ? { ...entry, customTitle: cached } : entry;
+    }
+
+    const filePath = path.join(sessionsDir, `${entry.sessionId}.jsonl`);
+    try {
+      const content = await fs.promises.readFile(filePath, 'utf-8');
+      const allLines = content.split(/\r?\n/).filter(l => l.trim());
+      const HEAD = 50;
+      const TAIL = 50;
+      const lines =
+        allLines.length <= HEAD + TAIL
+          ? allLines
+          : [...allLines.slice(0, HEAD), ...allLines.slice(-TAIL)];
+
+      let customTitle = '';
+      for (const line of lines) {
+        try {
+          const data = JSON.parse(line) as { type?: string; customTitle?: string };
+          if (data.type === 'custom-title' && typeof data.customTitle === 'string') {
+            customTitle = data.customTitle;
+          }
+        } catch {
+          // skip unparseable lines
+        }
+      }
+
+      this.customTitleCache.set(cacheKey, customTitle);
+      return customTitle ? { ...entry, customTitle } : entry;
+    } catch {
+      this.customTitleCache.set(cacheKey, '');
+      return entry;
     }
   }
 

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -112,6 +112,8 @@ export interface ClaudeSessionEntry {
   gitBranch: string;
   projectPath: string;
   isSidechain: boolean;
+  /** User-set title from Claude Code's /rename command */
+  customTitle?: string;
 }
 
 /** Claude Code's sessions-index.json format */


### PR DESCRIPTION
## Summary

- Redesigns the empty workspace state to mirror the shiroani idle view: muted icon cluster, eyebrow, editorial headline, dual CTAs, and a Recent panel wired to existing session history.
- Surfaces Claude Code `/rename` titles by reading `custom-title` events from session JSONL files; precedence is `customTitle > summary > firstPrompt`. Omniscribe-local renames still win in the sidebar.
- Computes real `messageCount` from JSONL (user + assistant lines) instead of the previous hardcoded `0`.

## Changes

- `IdleLandingView` rewritten — hero with 2x2 icon cluster (TerminalSquare / GitBranch / Layers / Sparkles, muted), `NO ACTIVE SESSIONS` eyebrow, headline, dual CTAs, `RECENT` panel with up to 3 sessions and `RESUME LAST ⌘⇧R` strip.
- `projectPath` threaded `App.tsx` -> `PersistentProjectGrid` -> `TerminalGrid` -> `IdleLandingView` so the panel can fetch per-project history.
- New `Mod+Shift+R` shortcut for "resume last", gated to idle state.
- `ClaudeSessionEntry.customTitle` added; both session readers (`apps/desktop/.../claude-session-reader.service.ts` and `packages/plugins/provider-claude/.../session-reader.service.ts`) extract last `custom-title` event and lazy-fill index entries via mtime cache.
- `messageCount` now computed during the existing full-file read in `extractEntryFromJsonl` — no extra IO.
- Pre-existing broken tests in `provider-claude` (stale readline mocks from a prior refactor) fixed; 2 new specs for messageCount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recent sessions panel on the idle landing screen showing up to 3 recent sessions with branch and message count metadata
  * Added keyboard shortcut (Cmd/Ctrl+Shift+R) to resume the last session
  * Custom session titles from Claude Code's rename command now extracted and displayed throughout the app

* **Improvements**
  * Session history now prioritizes custom titles when available, falling back to other metadata
  * Enhanced session metadata extraction for more reliable message counting and title information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->