### PR TITLE
feat: master plan PR 4 + 7 — perf quick wins + test hardening

### DIFF
--- a/apps/desktop/src/main/logger.spec.ts
+++ b/apps/desktop/src/main/logger.spec.ts
@@ -30,7 +30,7 @@ jest.mock('@omniscribe/shared', () => ({
   LOG_FILE_PREFIX: 'omniscribe',
   LOG_MAX_FILE_SIZE: 10 * 1024 * 1024,
   LOG_MAX_AGE_MS: 7 * 24 * 60 * 60 * 1000,
-  LOG_FLUSH_INTERVAL_MS: 100,
+  LOG_FLUSH_INTERVAL_MS: 500,
   LOG_BUFFER_MAX_ENTRIES: 50,
   LOG_CLEANUP_INTERVAL_MS: 60 * 60 * 1000,
   createLogger: () => ({
@@ -227,7 +227,7 @@ describe('logger', () => {
       mockStat.mockResolvedValue({ size: 0 });
 
       // Advance past the flush interval to trigger the timer and let async doFlush() complete
-      await jest.advanceTimersByTimeAsync(100); // LOG_FLUSH_INTERVAL_MS
+      await jest.advanceTimersByTimeAsync(500); // LOG_FLUSH_INTERVAL_MS
 
       expect(mockAppendFile).toHaveBeenCalledWith(
         expect.stringContaining('omniscribe-'),

--- a/apps/desktop/src/modules/git/git-status.service.spec.ts
+++ b/apps/desktop/src/modules/git/git-status.service.spec.ts
@@ -75,10 +75,8 @@ describe('GitStatusService', () => {
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
       // checkRebaseState: rev-parse --git-path rebase-apply
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
-      // checkRebaseState: ls-files rebase-merge (fails = no rebase)
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
-      // checkRebaseState: ls-files rebase-apply (fails = no rebase)
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
+      // checkRebaseState: existsSync(rebase-merge) + existsSync(rebase-apply)
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       // checkMergeState: rev-parse --git-path MERGE_HEAD
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       // checkMergeState: existsSync returns false (no merge)
@@ -113,8 +111,7 @@ describe('GitStatusService', () => {
       // checkRebaseState calls
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       // checkMergeState calls
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
@@ -141,8 +138,7 @@ describe('GitStatusService', () => {
       });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
@@ -167,8 +163,7 @@ describe('GitStatusService', () => {
       });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
@@ -192,8 +187,7 @@ describe('GitStatusService', () => {
       });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
@@ -215,8 +209,7 @@ describe('GitStatusService', () => {
       });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
@@ -240,8 +233,7 @@ describe('GitStatusService', () => {
       });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
@@ -268,8 +260,7 @@ describe('GitStatusService', () => {
       });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
@@ -302,8 +293,7 @@ describe('GitStatusService', () => {
       });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
@@ -378,38 +368,37 @@ describe('GitStatusService', () => {
   });
 
   describe('checkRebaseState', () => {
-    it('should return true when rebase-merge directory exists', async () => {
+    it('should return true when rebase-merge directory exists on disk', async () => {
       // rev-parse --git-path rebase-merge
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
       // rev-parse --git-path rebase-apply
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
-      // ls-files rebase-merge succeeds
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
+      // existsSync(rebase-merge) → true (rebase in progress)
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
 
       const result = await service.checkRebaseState('/repo');
 
       expect(result).toBe(true);
+      expect(fs.existsSync).toHaveBeenCalledWith('/repo/.git/rebase-merge');
     });
 
-    it('should return true when rebase-apply directory exists', async () => {
+    it('should return true when rebase-apply directory exists on disk', async () => {
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
-      // ls-files rebase-merge fails
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
-      // ls-files rebase-apply succeeds
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      // existsSync(rebase-merge) → false, existsSync(rebase-apply) → true
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(true);
 
       const result = await service.checkRebaseState('/repo');
 
       expect(result).toBe(true);
+      expect(fs.existsSync).toHaveBeenCalledWith('/repo/.git/rebase-apply');
     });
 
     it('should return false when neither rebase directory exists', async () => {
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
-      // Both ls-files fail
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
-      gitBase.execGit.mockRejectedValueOnce(new Error('not found'));
+      // Both existsSync calls return false
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
 
       const result = await service.checkRebaseState('/repo');
 
@@ -421,6 +410,47 @@ describe('GitStatusService', () => {
 
       const result = await service.checkRebaseState('/repo');
 
+      expect(result).toBe(false);
+    });
+
+    it('accepts rebase paths living in the shared git common dir (worktree)', async () => {
+      // Worktree case: rev-parse --git-path returns absolute paths into
+      // the main repo's .git dir, not inside the worktree itself.
+      gitBase.execGit
+        .mockResolvedValueOnce({
+          stdout: '/main-repo/.git/worktrees/feat/rebase-merge\n',
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: '/main-repo/.git/worktrees/feat/rebase-apply\n',
+          stderr: '',
+        })
+        // isInsideProjectOrGitCommon → rev-parse --git-common-dir
+        .mockResolvedValueOnce({ stdout: '/main-repo/.git\n', stderr: '' });
+      // existsSync(rebase-merge) → true (rebase in progress in worktree)
+      (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
+
+      const result = await service.checkRebaseState('/main-repo/.worktrees/feature');
+
+      expect(result).toBe(true);
+      expect(fs.existsSync).toHaveBeenCalledWith('/main-repo/.git/worktrees/feat/rebase-merge');
+    });
+
+    it('refuses to existsSync rebase paths outside both project and git-common-dir', async () => {
+      // Pretend a tampered config returns paths entirely outside both
+      // the project and the git common dir.
+      gitBase.execGit
+        .mockResolvedValueOnce({ stdout: '/etc/passwd\n', stderr: '' })
+        .mockResolvedValueOnce({ stdout: '/etc/shadow\n', stderr: '' })
+        // git-common-dir lookup for first candidate's safety check
+        .mockResolvedValueOnce({ stdout: '/main-repo/.git\n', stderr: '' })
+        // git-common-dir lookup for second candidate's safety check
+        .mockResolvedValueOnce({ stdout: '/main-repo/.git\n', stderr: '' });
+
+      const result = await service.checkRebaseState('/main-repo');
+
+      // The dangerous existsSync must NOT be called.
+      expect(fs.existsSync).not.toHaveBeenCalled();
       expect(result).toBe(false);
     });
   });

--- a/apps/desktop/src/modules/git/git-status.service.spec.ts
+++ b/apps/desktop/src/modules/git/git-status.service.spec.ts
@@ -71,10 +71,11 @@ describe('GitStatusService', () => {
         stdout: '# branch.oid abc123\n# branch.head main\n',
         stderr: '',
       });
-      // checkRebaseState: rev-parse --git-path rebase-merge
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
-      // checkRebaseState: rev-parse --git-path rebase-apply
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      // checkRebaseState: single batched rev-parse --git-path
+      gitBase.execGit.mockResolvedValueOnce({
+        stdout: '.git/rebase-merge\n.git/rebase-apply\n',
+        stderr: '',
+      });
       // checkRebaseState: existsSync(rebase-merge) + existsSync(rebase-apply)
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       // checkMergeState: rev-parse --git-path MERGE_HEAD
@@ -109,8 +110,10 @@ describe('GitStatusService', () => {
         stderr: '',
       });
       // checkRebaseState calls
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      gitBase.execGit.mockResolvedValueOnce({
+        stdout: '.git/rebase-merge\n.git/rebase-apply\n',
+        stderr: '',
+      });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       // checkMergeState calls
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
@@ -136,8 +139,10 @@ describe('GitStatusService', () => {
         stdout: '1 .M N... 100644 100644 100644 abc123 def456 src/app.ts\n',
         stderr: '',
       });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      gitBase.execGit.mockResolvedValueOnce({
+        stdout: '.git/rebase-merge\n.git/rebase-apply\n',
+        stderr: '',
+      });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
@@ -161,8 +166,10 @@ describe('GitStatusService', () => {
         stdout: '1 MM N... 100644 100644 100644 abc123 def456 src/app.ts\n',
         stderr: '',
       });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      gitBase.execGit.mockResolvedValueOnce({
+        stdout: '.git/rebase-merge\n.git/rebase-apply\n',
+        stderr: '',
+      });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
@@ -185,8 +192,10 @@ describe('GitStatusService', () => {
         stdout: '? newfile.ts\n? another.ts\n',
         stderr: '',
       });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      gitBase.execGit.mockResolvedValueOnce({
+        stdout: '.git/rebase-merge\n.git/rebase-apply\n',
+        stderr: '',
+      });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
@@ -207,8 +216,10 @@ describe('GitStatusService', () => {
         stdout: '2 R. N... 100644 100644 100644 abc123 def456 R100 new-name.ts\told-name.ts\n',
         stderr: '',
       });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      gitBase.execGit.mockResolvedValueOnce({
+        stdout: '.git/rebase-merge\n.git/rebase-apply\n',
+        stderr: '',
+      });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
@@ -231,8 +242,10 @@ describe('GitStatusService', () => {
         stdout: 'u UU N... 100644 100644 100644 100644 abc123 def456 ghi789 conflict.ts\n',
         stderr: '',
       });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      gitBase.execGit.mockResolvedValueOnce({
+        stdout: '.git/rebase-merge\n.git/rebase-apply\n',
+        stderr: '',
+      });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
@@ -258,8 +271,10 @@ describe('GitStatusService', () => {
         ].join('\n'),
         stderr: '',
       });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      gitBase.execGit.mockResolvedValueOnce({
+        stdout: '.git/rebase-merge\n.git/rebase-apply\n',
+        stderr: '',
+      });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
@@ -291,8 +306,10 @@ describe('GitStatusService', () => {
         ].join('\n'),
         stderr: '',
       });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      gitBase.execGit.mockResolvedValueOnce({
+        stdout: '.git/rebase-merge\n.git/rebase-apply\n',
+        stderr: '',
+      });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
       gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/MERGE_HEAD\n', stderr: '' });
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
@@ -369,10 +386,11 @@ describe('GitStatusService', () => {
 
   describe('checkRebaseState', () => {
     it('should return true when rebase-merge directory exists on disk', async () => {
-      // rev-parse --git-path rebase-merge
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
-      // rev-parse --git-path rebase-apply
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      // single batched rev-parse returns both paths on separate lines
+      gitBase.execGit.mockResolvedValueOnce({
+        stdout: '.git/rebase-merge\n.git/rebase-apply\n',
+        stderr: '',
+      });
       // existsSync(rebase-merge) → true (rebase in progress)
       (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
 
@@ -383,8 +401,10 @@ describe('GitStatusService', () => {
     });
 
     it('should return true when rebase-apply directory exists on disk', async () => {
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      gitBase.execGit.mockResolvedValueOnce({
+        stdout: '.git/rebase-merge\n.git/rebase-apply\n',
+        stderr: '',
+      });
       // existsSync(rebase-merge) → false, existsSync(rebase-apply) → true
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(true);
 
@@ -395,8 +415,10 @@ describe('GitStatusService', () => {
     });
 
     it('should return false when neither rebase directory exists', async () => {
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-merge\n', stderr: '' });
-      gitBase.execGit.mockResolvedValueOnce({ stdout: '.git/rebase-apply\n', stderr: '' });
+      gitBase.execGit.mockResolvedValueOnce({
+        stdout: '.git/rebase-merge\n.git/rebase-apply\n',
+        stderr: '',
+      });
       // Both existsSync calls return false
       (fs.existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(false);
 
@@ -414,15 +436,12 @@ describe('GitStatusService', () => {
     });
 
     it('accepts rebase paths living in the shared git common dir (worktree)', async () => {
-      // Worktree case: rev-parse --git-path returns absolute paths into
+      // Worktree case: batched rev-parse --git-path returns absolute paths into
       // the main repo's .git dir, not inside the worktree itself.
       gitBase.execGit
         .mockResolvedValueOnce({
-          stdout: '/main-repo/.git/worktrees/feat/rebase-merge\n',
-          stderr: '',
-        })
-        .mockResolvedValueOnce({
-          stdout: '/main-repo/.git/worktrees/feat/rebase-apply\n',
+          stdout:
+            '/main-repo/.git/worktrees/feat/rebase-merge\n/main-repo/.git/worktrees/feat/rebase-apply\n',
           stderr: '',
         })
         // isInsideProjectOrGitCommon → rev-parse --git-common-dir
@@ -440,8 +459,7 @@ describe('GitStatusService', () => {
       // Pretend a tampered config returns paths entirely outside both
       // the project and the git common dir.
       gitBase.execGit
-        .mockResolvedValueOnce({ stdout: '/etc/passwd\n', stderr: '' })
-        .mockResolvedValueOnce({ stdout: '/etc/shadow\n', stderr: '' })
+        .mockResolvedValueOnce({ stdout: '/etc/passwd\n/etc/shadow\n', stderr: '' })
         // git-common-dir lookup for first candidate's safety check
         .mockResolvedValueOnce({ stdout: '/main-repo/.git\n', stderr: '' })
         // git-common-dir lookup for second candidate's safety check

--- a/apps/desktop/src/modules/git/git-status.service.ts
+++ b/apps/desktop/src/modules/git/git-status.service.ts
@@ -191,36 +191,46 @@ export class GitStatusService {
   }
 
   /**
-   * Check if rebase is in progress
+   * Check if rebase is in progress by testing whether rebase-merge or
+   * rebase-apply directories exist on disk. Mirrors `checkMergeState`'s
+   * `rev-parse --git-path` + `existsSync` pattern instead of the prior
+   * 4-spawn approach (`git rev-parse` ×2 + `git ls-files --error-unmatch`
+   * ×2). Saves ~80 ms per `getStatus()`.
    */
   async checkRebaseState(projectPath: string): Promise<boolean> {
     try {
-      const { stdout } = await this.gitBase.execGit(projectPath, [
+      // rev-parse --git-path resolves the actual filesystem path for each
+      // rebase directory (works correctly in worktrees where .git is a
+      // file pointing at the shared common dir).
+      const { stdout: mergeOut } = await this.gitBase.execGit(projectPath, [
         'rev-parse',
         '--git-path',
         'rebase-merge',
       ]);
-      const rebaseMergePath = stdout.trim();
-
-      const { stdout: rebaseApplyOutput } = await this.gitBase.execGit(projectPath, [
+      const { stdout: applyOut } = await this.gitBase.execGit(projectPath, [
         'rev-parse',
         '--git-path',
         'rebase-apply',
       ]);
-      const rebaseApplyPath = rebaseApplyOutput.trim();
 
-      // Check if either rebase directory exists
-      const { stdout: lsOutput } = await this.gitBase
-        .execGit(projectPath, ['ls-files', '--error-unmatch', rebaseMergePath])
-        .catch(() => ({ stdout: '' }));
+      const candidates = [mergeOut.trim(), applyOut.trim()].filter(p => p.length > 0);
 
-      if (lsOutput) return true;
+      for (const rel of candidates) {
+        const fullPath = resolve(projectPath, rel);
 
-      const { stdout: lsApplyOutput } = await this.gitBase
-        .execGit(projectPath, ['ls-files', '--error-unmatch', rebaseApplyPath])
-        .catch(() => ({ stdout: '' }));
+        // Defense: a tampered git config could in principle make
+        // --git-path point outside the worktree's project + common dir.
+        // Refuse to existsSync arbitrary paths.
+        if (!(await this.isInsideProjectOrGitCommon(projectPath, fullPath))) {
+          this.logger.warn(
+            `Refusing existsSync — rebase path outside project/git-common-dir: ${fullPath}`
+          );
+          continue;
+        }
+        if (existsSync(fullPath)) return true;
+      }
 
-      return !!lsApplyOutput;
+      return false;
     } catch (error) {
       this.logger.warn('Failed to check rebase state:', error);
       return false;

--- a/apps/desktop/src/modules/git/git-status.service.ts
+++ b/apps/desktop/src/modules/git/git-status.service.ts
@@ -195,25 +195,27 @@ export class GitStatusService {
    * rebase-apply directories exist on disk. Mirrors `checkMergeState`'s
    * `rev-parse --git-path` + `existsSync` pattern instead of the prior
    * 4-spawn approach (`git rev-parse` ×2 + `git ls-files --error-unmatch`
-   * ×2). Saves ~80 ms per `getStatus()`.
+   * ×2). Batches both `--git-path` flags into 1 spawn — saves ~80–100 ms
+   * per `getStatus()`.
    */
   async checkRebaseState(projectPath: string): Promise<boolean> {
     try {
-      // rev-parse --git-path resolves the actual filesystem path for each
-      // rebase directory (works correctly in worktrees where .git is a
-      // file pointing at the shared common dir).
-      const { stdout: mergeOut } = await this.gitBase.execGit(projectPath, [
+      // rev-parse accepts multiple --git-path flags and emits one resolved
+      // path per line. Works correctly in worktrees where .git is a file
+      // pointing at the shared common dir.
+      const { stdout } = await this.gitBase.execGit(projectPath, [
         'rev-parse',
         '--git-path',
         'rebase-merge',
-      ]);
-      const { stdout: applyOut } = await this.gitBase.execGit(projectPath, [
-        'rev-parse',
         '--git-path',
         'rebase-apply',
       ]);
 
-      const candidates = [mergeOut.trim(), applyOut.trim()].filter(p => p.length > 0);
+      const candidates = stdout
+        .trim()
+        .split('\n')
+        .map(p => p.trim())
+        .filter(p => p.length > 0);
 
       for (const rel of candidates) {
         const fullPath = resolve(projectPath, rel);

--- a/apps/desktop/src/modules/health/health.service.spec.ts
+++ b/apps/desktop/src/modules/health/health.service.spec.ts
@@ -459,4 +459,96 @@ describe('HealthService', () => {
       expect(() => service.checkHealth()).not.toThrow();
     });
   });
+
+  // ==================================================================
+  // determineHealth edge cases
+  // ==================================================================
+  describe('determineHealth edge cases', () => {
+    it('should return healthy for working session that has never produced output (lastOutputAt undefined)', () => {
+      // The output-stale check guards with `if (lastOutput > 0 && ...)`.
+      // A session that spawned but hasn't produced any output yet must not
+      // be immediately flagged as degraded.
+      const session = makeSession({ status: 'working', lastOutputAt: undefined });
+      sessionService.getAll.mockReturnValue([session]);
+      jest.spyOn(process, 'kill').mockImplementation(() => true);
+
+      service.checkHealth();
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        InternalSessionEvents.HEALTH,
+        expect.objectContaining({ health: 'healthy' })
+      );
+    });
+
+    it('should not fail for error state session when lastActiveAt is undefined', () => {
+      // The error-duration check guards with `if (session.status === 'error' && session.lastActiveAt)`.
+      // An error session without lastActiveAt must not crash and must be considered healthy
+      // (the guard short-circuits before the duration math).
+      const session = makeSession({ status: 'error', lastActiveAt: undefined as any });
+      sessionService.getAll.mockReturnValue([session]);
+      jest.spyOn(process, 'kill').mockImplementation(() => true);
+
+      expect(() => service.checkHealth()).not.toThrow();
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        InternalSessionEvents.HEALTH,
+        expect.objectContaining({ health: 'healthy' })
+      );
+    });
+
+    it('should return healthy for a recently-errored session (under 2-minute threshold)', () => {
+      const thirtySecondsAgo = new Date(Date.now() - 30_000);
+      const session = makeSession({ status: 'error', lastActiveAt: thirtySecondsAgo });
+      sessionService.getAll.mockReturnValue([session]);
+      jest.spyOn(process, 'kill').mockImplementation(() => true);
+
+      service.checkHealth();
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        InternalSessionEvents.HEALTH,
+        expect.objectContaining({ health: 'healthy' })
+      );
+    });
+
+    it('should return healthy for planning/finished/connecting sessions (not in WORKING or IDLE sets)', () => {
+      // These statuses fall through both WORKING_STATUSES and IDLE_STATUSES checks
+      // and land at the final catch-all `return { level: 'healthy' }`.
+      for (const status of ['planning', 'finished', 'connecting'] as const) {
+        eventEmitter.emit.mockClear();
+        const session = makeSession({ status: status as any });
+        sessionService.getAll.mockReturnValue([session]);
+        jest.spyOn(process, 'kill').mockImplementation(() => true);
+
+        service.checkHealth();
+
+        expect(eventEmitter.emit).toHaveBeenCalledWith(
+          InternalSessionEvents.HEALTH,
+          expect.objectContaining({ health: 'healthy' })
+        );
+      }
+    });
+
+    it('should emit CLEANUP with the zombie reason string for each failed session', () => {
+      // Verify the reason field propagates correctly from cleanupZombie to the event.
+      const session = makeSession();
+      sessionService.getAll.mockReturnValue([session]);
+      // PID not alive → failed
+      const esrch = new Error('No such process') as NodeJS.ErrnoException;
+      esrch.code = 'ESRCH';
+      jest.spyOn(process, 'kill').mockImplementation(() => {
+        throw esrch;
+      });
+      // cleanupZombie: terminal still in map for kill step
+      terminalService.hasSession.mockReturnValueOnce(true).mockReturnValueOnce(true);
+
+      service.checkHealth();
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        InternalZombieEvents.CLEANUP,
+        expect.objectContaining({
+          reason: 'Terminal process terminated unexpectedly',
+        })
+      );
+    });
+  });
 });

--- a/apps/desktop/src/modules/session/session.service.spec.ts
+++ b/apps/desktop/src/modules/session/session.service.spec.ts
@@ -5,6 +5,11 @@ import { TerminalService } from '../terminal/terminal.service';
 import { WorktreeService } from '../git/worktree.service';
 import { WorkspaceService } from '../workspace/workspace.service';
 import type { SessionStatus } from '@omniscribe/shared';
+import {
+  MAX_SESSION_NAME_LENGTH,
+  MAX_MODEL_LENGTH,
+  MAX_SYSTEM_PROMPT_LENGTH,
+} from '@omniscribe/shared';
 
 describe('SessionService', () => {
   let service: SessionService;
@@ -295,6 +300,85 @@ describe('SessionService', () => {
         expect(result).toBeUndefined();
         expect(service.get(session.id)?.status).toBe('idle');
       });
+    });
+  });
+
+  describe('update', () => {
+    it('should update session name when within length limit', () => {
+      const session = service.create('claude', '/project');
+
+      const result = service.update(session.id, { name: 'Updated Name' });
+
+      expect(result).toBeDefined();
+      expect(service.get(session.id)?.name).toBe('Updated Name');
+    });
+
+    it('should reject name exceeding MAX_SESSION_NAME_LENGTH and return undefined', () => {
+      const session = service.create('claude', '/project');
+      const originalName = session.name;
+      const tooLong = 'x'.repeat(MAX_SESSION_NAME_LENGTH + 1);
+
+      const result = service.update(session.id, { name: tooLong });
+
+      expect(result).toBeUndefined();
+      expect(service.get(session.id)?.name).toBe(originalName);
+    });
+
+    it('should reject model exceeding MAX_MODEL_LENGTH and return undefined', () => {
+      const session = service.create('claude', '/project', { model: 'claude-3-sonnet' });
+      const tooLong = 'x'.repeat(MAX_MODEL_LENGTH + 1);
+
+      const result = service.update(session.id, { model: tooLong });
+
+      expect(result).toBeUndefined();
+      expect(service.get(session.id)?.model).toBe('claude-3-sonnet');
+    });
+
+    it('should reject systemPrompt exceeding MAX_SYSTEM_PROMPT_LENGTH and return undefined', () => {
+      const session = service.create('claude', '/project', { systemPrompt: 'original prompt' });
+      const tooLong = 'x'.repeat(MAX_SYSTEM_PROMPT_LENGTH + 1);
+
+      const result = service.update(session.id, { systemPrompt: tooLong });
+
+      expect(result).toBeUndefined();
+      expect(service.get(session.id)?.systemPrompt).toBe('original prompt');
+    });
+
+    it('should accept name exactly at MAX_SESSION_NAME_LENGTH', () => {
+      const session = service.create('claude', '/project');
+      const atLimit = 'x'.repeat(MAX_SESSION_NAME_LENGTH);
+
+      const result = service.update(session.id, { name: atLimit });
+
+      expect(result).toBeDefined();
+      expect(service.get(session.id)?.name).toBe(atLimit);
+    });
+
+    it('should return undefined for non-existent session', () => {
+      const result = service.update('nonexistent', { name: 'New Name' });
+      expect(result).toBeUndefined();
+    });
+
+    it('should emit session.status event on successful update', () => {
+      const session = service.create('claude', '/project');
+      eventEmitter.emit.mockClear();
+
+      service.update(session.id, { name: 'Updated' });
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'session.status',
+        expect.objectContaining({ sessionId: session.id })
+      );
+    });
+
+    it('should not emit any event when a length limit is exceeded', () => {
+      const session = service.create('claude', '/project');
+      eventEmitter.emit.mockClear();
+      const tooLong = 'x'.repeat(MAX_SESSION_NAME_LENGTH + 1);
+
+      service.update(session.id, { name: tooLong });
+
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/modules/session/session.service.spec.ts
+++ b/apps/desktop/src/modules/session/session.service.spec.ts
@@ -354,6 +354,44 @@ describe('SessionService', () => {
       expect(service.get(session.id)?.name).toBe(atLimit);
     });
 
+    it('should update model when within length limit', () => {
+      const session = service.create('claude', '/project');
+
+      const result = service.update(session.id, { model: 'claude-4-opus' });
+
+      expect(result).toBeDefined();
+      expect(service.get(session.id)?.model).toBe('claude-4-opus');
+    });
+
+    it('should accept model exactly at MAX_MODEL_LENGTH', () => {
+      const session = service.create('claude', '/project');
+      const atLimit = 'x'.repeat(MAX_MODEL_LENGTH);
+
+      const result = service.update(session.id, { model: atLimit });
+
+      expect(result).toBeDefined();
+      expect(service.get(session.id)?.model).toBe(atLimit);
+    });
+
+    it('should update systemPrompt when within length limit', () => {
+      const session = service.create('claude', '/project');
+
+      const result = service.update(session.id, { systemPrompt: 'Be concise.' });
+
+      expect(result).toBeDefined();
+      expect(service.get(session.id)?.systemPrompt).toBe('Be concise.');
+    });
+
+    it('should accept systemPrompt exactly at MAX_SYSTEM_PROMPT_LENGTH', () => {
+      const session = service.create('claude', '/project');
+      const atLimit = 'x'.repeat(MAX_SYSTEM_PROMPT_LENGTH);
+
+      const result = service.update(session.id, { systemPrompt: atLimit });
+
+      expect(result).toBeDefined();
+      expect(service.get(session.id)?.systemPrompt).toBe(atLimit);
+    });
+
     it('should return undefined for non-existent session', () => {
       const result = service.update('nonexistent', { name: 'New Name' });
       expect(result).toBeUndefined();

--- a/apps/desktop/src/modules/terminal/terminal.gateway.spec.ts
+++ b/apps/desktop/src/modules/terminal/terminal.gateway.spec.ts
@@ -46,6 +46,8 @@ describe('TerminalGateway', () => {
       kill: jest.fn().mockResolvedValue(undefined),
       hasSession: jest.fn().mockReturnValue(true),
       getScrollback: jest.fn().mockReturnValue(null),
+      pause: jest.fn(),
+      resume: jest.fn(),
     } as unknown as jest.Mocked<TerminalService>;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -806,9 +808,12 @@ describe('TerminalGateway', () => {
   // =========================================================================
 
   describe('backpressure', () => {
-    it('should pause terminal when pending chars exceed HIGH_WATER_MARK', () => {
-      terminalService.pause = jest.fn();
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    });
 
+    it('should pause terminal when pending chars exceed HIGH_WATER_MARK', () => {
       // Emit enough data to exceed ~250KB (HIGH_WATER_MARK = 256_000)
       const largeData = 'x'.repeat(260_000);
       gateway.handleTerminalOutput({ sessionId: 1, data: largeData });
@@ -817,8 +822,6 @@ describe('TerminalGateway', () => {
     });
 
     it('should track chars not packets — many small writes should not trigger', () => {
-      terminalService.pause = jest.fn();
-
       // 100 small packets (100 chars total — well below 256KB)
       for (let i = 0; i < 100; i++) {
         gateway.handleTerminalOutput({ sessionId: 1, data: 'x' });
@@ -828,8 +831,6 @@ describe('TerminalGateway', () => {
     });
 
     it('should not pause the same terminal twice', () => {
-      terminalService.pause = jest.fn();
-
       // First call triggers pause
       gateway.handleTerminalOutput({ sessionId: 1, data: 'x'.repeat(260_000) });
       expect(terminalService.pause).toHaveBeenCalledTimes(1);
@@ -837,6 +838,52 @@ describe('TerminalGateway', () => {
       // Second call should not re-pause (already paused)
       gateway.handleTerminalOutput({ sessionId: 1, data: 'x'.repeat(260_000) });
       expect(terminalService.pause).toHaveBeenCalledTimes(1);
+    });
+
+    // PAUSE_SAFETY_TIMEOUT_MS force-resume: if the drain event never fires
+    // (e.g. the client closes or stalls), the 15s safety timeout must
+    // force-resume the PTY so Claude is never permanently deadlocked.
+    it('should force-resume after PAUSE_SAFETY_TIMEOUT_MS (15s) without manual drain', () => {
+      jest.useFakeTimers();
+
+      // Trigger backpressure pause
+      gateway.handleTerminalOutput({ sessionId: 1, data: 'x'.repeat(260_000) });
+      expect(terminalService.pause).toHaveBeenCalledWith(1);
+
+      // Terminal is now paused; drain event never arrives.
+      // Before the safety timeout fires, resume should NOT have been called.
+      jest.advanceTimersByTime(14_999);
+      expect(terminalService.resume).not.toHaveBeenCalled();
+
+      // Advance past the 15s safety window — force-resume must fire.
+      jest.advanceTimersByTime(2);
+      expect(terminalService.resume).toHaveBeenCalledWith(1);
+    });
+
+    it('should NOT force-resume when drain clears backpressure before the timeout', () => {
+      jest.useFakeTimers();
+
+      const client = createMockSocket('c1');
+      let drainCallback: (() => void) | undefined;
+      client.conn.on = jest.fn((_event: string, cb: () => void) => {
+        drainCallback = cb;
+      });
+
+      gateway.handleConnection(client);
+
+      // Trigger backpressure pause
+      gateway.handleTerminalOutput({ sessionId: 1, data: 'x'.repeat(260_000) });
+      expect(terminalService.pause).toHaveBeenCalledWith(1);
+
+      // Drain fires at 5s — clears pause and cancels the safety timeout.
+      jest.advanceTimersByTime(5_000);
+      drainCallback?.();
+      expect(terminalService.resume).toHaveBeenCalledWith(1);
+
+      // Advance past the original 15s window to confirm the timer was cancelled
+      // (resume must only have been called once — from the drain, not from timeout).
+      jest.advanceTimersByTime(11_000);
+      expect(terminalService.resume).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/web/src/lib/__tests__/session-mappers.test.ts
+++ b/apps/web/src/lib/__tests__/session-mappers.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { mapToTerminalSessions } from '../session-mappers';
+import type { FrontendSessionConfig } from '@/stores/useSessionStore';
+
+function makeSession(overrides: Partial<FrontendSessionConfig> = {}): FrontendSessionConfig {
+  return {
+    id: 'sess-1',
+    name: 'Test',
+    workingDirectory: '/test',
+    aiMode: 'claude',
+    projectPath: '/test/project',
+    status: 'working',
+    createdAt: new Date(),
+    lastActiveAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('mapToTerminalSessions', () => {
+  it('returns the same per-session output object when inputs are referentially equal', () => {
+    // The map cache is keyed on the FrontendSessionConfig reference, so
+    // the same source + same customTitle + same slot index → same output
+    // ref. This is what lets React.memo'd TerminalCards skip re-renders
+    // during status fan-outs that don't actually change the source.
+    const session = makeSession({ id: 'sess-1' });
+    const titles: Record<string, string> = {};
+
+    const first = mapToTerminalSessions([session], titles);
+    const second = mapToTerminalSessions([session], titles);
+
+    expect(second[0]).toBe(first[0]);
+  });
+
+  it('rotates the output when the source session reference changes', () => {
+    const titles: Record<string, string> = {};
+    const v1 = makeSession({ id: 'sess-1', status: 'idle' });
+    const v2 = { ...v1, status: 'working' as const };
+
+    const first = mapToTerminalSessions([v1], titles);
+    const second = mapToTerminalSessions([v2], titles);
+
+    expect(second[0]).not.toBe(first[0]);
+    expect(second[0].status).toBe('working');
+  });
+
+  it('rotates the output when the customTitle for a session changes', () => {
+    const session = makeSession({ id: 'sess-1' });
+
+    const first = mapToTerminalSessions([session], {});
+    const second = mapToTerminalSessions([session], { 'sess-1': 'Renamed' });
+
+    expect(second[0]).not.toBe(first[0]);
+    expect(second[0].customTitle).toBe('Renamed');
+  });
+
+  it('rotates the output when the slot number (index) changes', () => {
+    const a = makeSession({ id: 'sess-a' });
+    const b = makeSession({ id: 'sess-b' });
+    const titles: Record<string, string> = {};
+
+    const first = mapToTerminalSessions([a, b], titles);
+    // Same `a` reference, but now at index 1 instead of 0 → different
+    // sessionNumber → cache miss expected.
+    const second = mapToTerminalSessions([b, a], titles);
+
+    expect(second[1]).not.toBe(first[0]);
+    expect(second[1].sessionNumber).toBe(2);
+    expect(first[0].sessionNumber).toBe(1);
+  });
+
+  it('produces stable references for unchanged neighbors when one session is updated', () => {
+    // The targeted re-render path: one session ticks, others should
+    // keep their cached output object.
+    const a = makeSession({ id: 'sess-a', status: 'idle' });
+    const b = makeSession({ id: 'sess-b', status: 'working' });
+    const titles: Record<string, string> = {};
+
+    const first = mapToTerminalSessions([a, b], titles);
+
+    // `a` rotates; `b` stays the same reference.
+    const aV2 = { ...a, status: 'working' as const };
+    const second = mapToTerminalSessions([aV2, b], titles);
+
+    expect(second[0]).not.toBe(first[0]);
+    expect(second[1]).toBe(first[1]);
+  });
+});

--- a/apps/web/src/lib/session-mappers.ts
+++ b/apps/web/src/lib/session-mappers.ts
@@ -3,25 +3,62 @@ import type { FrontendSessionConfig } from '@/stores/useSessionStore';
 import type { TerminalSession } from '@/components/terminal/TerminalGrid';
 
 /**
+ * Per-session memoization for {@link mapToTerminalSessions}. Keyed on the
+ * source `FrontendSessionConfig` reference (which the store rotates only
+ * when something actually changed for that session), then validated against
+ * the inputs that affect the projected output (sessionNumber and customTitle).
+ *
+ * `WeakMap` so cached entries are GC'd alongside their session config when
+ * the store drops them from `state.sessions`.
+ *
+ * Note: `mapSessionStatus(session.status)` and the spread of static fields
+ * (`aiMode`, `branch`, `worktreePath`, …) are derived from the same session
+ * reference, so cache validity collapses to:
+ *   same session ref AND same sessionNumber AND same customTitle
+ */
+interface CacheEntry {
+  sessionNumber: number;
+  customTitle: string | undefined;
+  out: TerminalSession;
+}
+
+const mapCache = new WeakMap<FrontendSessionConfig, CacheEntry>();
+
+/**
  * Maps raw FrontendSessionConfig entries to TerminalSession format for TerminalGrid.
  * Shared between useProjectSessions and PersistentProjectGrid to avoid duplication.
+ *
+ * Returns referentially-stable per-session output objects when the source
+ * session reference, its slot number, and its custom title are all
+ * unchanged. Lets `React.memo`-wrapped TerminalCard skip re-renders during
+ * status-tick fan-outs that don't actually change the rendered fields.
  */
 export function mapToTerminalSessions(
   sessions: FrontendSessionConfig[],
   customTitles: Record<string, string>
 ): TerminalSession[] {
-  return sessions.map((session, index) => ({
-    id: session.id,
-    sessionNumber: index + 1,
-    aiMode: session.aiMode,
-    status: mapSessionStatus(session.status),
-    branch: session.branch,
-    statusMessage: session.statusMessage,
-    terminalSessionId: session.terminalSessionId,
-    worktreePath: session.worktreePath,
-    skipPermissions: session.skipPermissions,
-    claudeSessionId: session.claudeSessionId,
-    isResumed: session.isResumed,
-    customTitle: customTitles[session.id],
-  }));
+  return sessions.map((session, index) => {
+    const sessionNumber = index + 1;
+    const customTitle = customTitles[session.id];
+    const cached = mapCache.get(session);
+    if (cached && cached.sessionNumber === sessionNumber && cached.customTitle === customTitle) {
+      return cached.out;
+    }
+    const out: TerminalSession = {
+      id: session.id,
+      sessionNumber,
+      aiMode: session.aiMode,
+      status: mapSessionStatus(session.status),
+      branch: session.branch,
+      statusMessage: session.statusMessage,
+      terminalSessionId: session.terminalSessionId,
+      worktreePath: session.worktreePath,
+      skipPermissions: session.skipPermissions,
+      claudeSessionId: session.claudeSessionId,
+      isResumed: session.isResumed,
+      customTitle,
+    };
+    mapCache.set(session, { sessionNumber, customTitle, out });
+    return out;
+  });
 }

--- a/apps/web/src/stores/__tests__/useSessionStore.test.ts
+++ b/apps/web/src/stores/__tests__/useSessionStore.test.ts
@@ -180,7 +180,11 @@ describe('useSessionStore', () => {
       expect(updated.name).toBe('New Name');
     });
 
-    it('updates lastActiveAt on change', () => {
+    it('does not bump renderer-side lastActiveAt (kept stable to avoid fan-out)', () => {
+      // Renderer dropped its lastActiveAt bump in PR 4 perf #1: the
+      // backend still stamps its own timestamp and ships it on the wire.
+      // The renderer must NOT rotate this field on every store write —
+      // that would fan out re-renders to every consumer.
       const oldDate = new Date(2020, 0, 1);
       const session = createMockSession({ id: 'sess-1', lastActiveAt: oldDate });
       useSessionStore.setState({ sessions: [session] });
@@ -188,7 +192,7 @@ describe('useSessionStore', () => {
       useSessionStore.getState().updateSession('sess-1', { name: 'Updated' });
 
       const updated = useSessionStore.getState().sessions[0];
-      expect(updated.lastActiveAt.getTime()).toBeGreaterThan(oldDate.getTime());
+      expect(updated.lastActiveAt).toBe(oldDate);
     });
 
     it('does not affect other sessions', () => {
@@ -257,6 +261,48 @@ describe('useSessionStore', () => {
 
       const updated = useSessionStore.getState().sessions[0];
       expect(updated.needsInputPrompt).toBe(true);
+    });
+
+    it('preserves array and session reference when nothing UI-relevant changed', () => {
+      // Backend re-emits status events on every PTY tick. Most carry the
+      // same payload (idle→idle, working→working with the same message).
+      // updateStatus must early-return same state in that case so
+      // useShallow / React.memo consumers don't fan out re-renders.
+      const session = createMockSession({
+        id: 'sess-1',
+        status: 'working' as SessionStatus,
+        statusMessage: 'thinking',
+        needsInputPrompt: false,
+      });
+      useSessionStore.setState({ sessions: [session] });
+      const sessionsBefore = useSessionStore.getState().sessions;
+
+      useSessionStore
+        .getState()
+        .updateStatus('sess-1', 'working', 'thinking', false, undefined, undefined, undefined);
+
+      const sessionsAfter = useSessionStore.getState().sessions;
+      // Array reference preserved
+      expect(sessionsAfter).toBe(sessionsBefore);
+      // Session reference preserved
+      expect(sessionsAfter[0]).toBe(session);
+    });
+
+    it('still emits a new reference when status flips', () => {
+      const session = createMockSession({
+        id: 'sess-1',
+        status: 'idle' as SessionStatus,
+        statusMessage: 'waiting',
+      });
+      useSessionStore.setState({ sessions: [session] });
+      const sessionsBefore = useSessionStore.getState().sessions;
+
+      useSessionStore.getState().updateStatus('sess-1', 'working', 'waiting');
+
+      const sessionsAfter = useSessionStore.getState().sessions;
+      expect(sessionsAfter).not.toBe(sessionsBefore);
+      expect(sessionsAfter[0]).not.toBe(session);
+      expect(sessionsAfter[0].status).toBe('working');
     });
   });
 

--- a/apps/web/src/stores/__tests__/useSessionStore.test.ts
+++ b/apps/web/src/stores/__tests__/useSessionStore.test.ts
@@ -430,6 +430,89 @@ describe('useSessionStore', () => {
         expect(result).toHaveLength(2);
         expect(result.map(s => s.id)).toEqual(['s2', 's4']);
       });
+
+      // TODO: unskip after PR 4 lands (fan-out re-render fix)
+      // PR 4 adds early-return in updateStatus when no UI-relevant field changes,
+      // so the Zustand state reference does not change and the memoized selector
+      // never needs to re-evaluate. The selector itself already returns a stable
+      // reference via createMemoizedSelector (shallow equality), but the store
+      // keeps firing state updates today even when nothing material changes.
+      // These assertions pin the EXPECTED post-PR-4 selector contract.
+      it.skip('returns same reference when unrelated state field changes (Object.is)', () => {
+        const sessions = [
+          createMockSession({ id: 's1', status: 'working' }),
+          createMockSession({ id: 's2', status: 'idle' }),
+        ];
+        useSessionStore.setState({ sessions });
+
+        const stateA = useSessionStore.getState();
+        const first = selectActiveSessions(stateA);
+
+        // Simulate an update that does NOT change which sessions are active
+        // (e.g. lastActiveAt bumped on an idle session — not in the active list)
+        const updatedSessions = sessions.map(s =>
+          s.id === 's2' ? { ...s, lastActiveAt: new Date() } : s
+        );
+        useSessionStore.setState({ sessions: updatedSessions });
+        const stateB = useSessionStore.getState();
+        const second = selectActiveSessions(stateB);
+
+        expect(Object.is(first, second)).toBe(true);
+      });
+    });
+
+    // Fan-out stable-reference assertions for selectSessionsForProject.
+    // TODO: unskip after PR 4 lands (fan-out re-render fix)
+    // See comment above on selectActiveSessions for background.
+    describe('selectSessionsForProject — stable reference (fan-out guard)', () => {
+      it.skip('returns same reference when sessions for other projects change (Object.is)', () => {
+        const sessA = createMockSession({ id: 's1', projectPath: '/proj-a', status: 'working' });
+        const sessB = createMockSession({ id: 's2', projectPath: '/proj-b', status: 'idle' });
+        useSessionStore.setState({ sessions: [sessA, sessB] });
+
+        const selector = selectSessionsForProject('/proj-a');
+
+        const stateA = useSessionStore.getState();
+        const first = selector(stateA);
+
+        // Update only the /proj-b session — /proj-a result must not change
+        const updated = [sessA, { ...sessB, lastActiveAt: new Date() }];
+        useSessionStore.setState({ sessions: updated });
+        const stateB = useSessionStore.getState();
+        const second = selector(stateB);
+
+        expect(Object.is(first, second)).toBe(true);
+      });
+
+      it('returns a new reference when sessions for the project actually change', () => {
+        const sessA = createMockSession({ id: 's1', projectPath: '/proj-a', status: 'idle' });
+        useSessionStore.setState({ sessions: [sessA] });
+
+        const selector = selectSessionsForProject('/proj-a');
+        const first = selector(useSessionStore.getState());
+
+        // Add a new session for /proj-a — reference must update
+        const sessA2 = createMockSession({ id: 's2', projectPath: '/proj-a', status: 'idle' });
+        useSessionStore.setState({ sessions: [sessA, sessA2] });
+        const second = selector(useSessionStore.getState());
+
+        expect(Object.is(first, second)).toBe(false);
+        expect(second).toHaveLength(2);
+      });
+
+      it('returns same reference on back-to-back identical state reads', () => {
+        const sessions = [
+          createMockSession({ id: 's1', projectPath: '/proj-a', status: 'working' }),
+        ];
+        useSessionStore.setState({ sessions });
+
+        const selector = selectSessionsForProject('/proj-a');
+        const state = useSessionStore.getState();
+        const first = selector(state);
+        const second = selector(state);
+
+        expect(Object.is(first, second)).toBe(true);
+      });
     });
 
     describe('selectRunningSessionCount', () => {

--- a/apps/web/src/stores/__tests__/useSessionStore.test.ts
+++ b/apps/web/src/stores/__tests__/useSessionStore.test.ts
@@ -477,14 +477,7 @@ describe('useSessionStore', () => {
         expect(result.map(s => s.id)).toEqual(['s2', 's4']);
       });
 
-      // TODO: unskip after PR 4 lands (fan-out re-render fix)
-      // PR 4 adds early-return in updateStatus when no UI-relevant field changes,
-      // so the Zustand state reference does not change and the memoized selector
-      // never needs to re-evaluate. The selector itself already returns a stable
-      // reference via createMemoizedSelector (shallow equality), but the store
-      // keeps firing state updates today even when nothing material changes.
-      // These assertions pin the EXPECTED post-PR-4 selector contract.
-      it.skip('returns same reference when unrelated state field changes (Object.is)', () => {
+      it('returns same reference when unrelated state field changes (Object.is)', () => {
         const sessions = [
           createMockSession({ id: 's1', status: 'working' }),
           createMockSession({ id: 's2', status: 'idle' }),
@@ -507,11 +500,8 @@ describe('useSessionStore', () => {
       });
     });
 
-    // Fan-out stable-reference assertions for selectSessionsForProject.
-    // TODO: unskip after PR 4 lands (fan-out re-render fix)
-    // See comment above on selectActiveSessions for background.
     describe('selectSessionsForProject — stable reference (fan-out guard)', () => {
-      it.skip('returns same reference when sessions for other projects change (Object.is)', () => {
+      it('returns same reference when sessions for other projects change (Object.is)', () => {
         const sessA = createMockSession({ id: 's1', projectPath: '/proj-a', status: 'working' });
         const sessB = createMockSession({ id: 's2', projectPath: '/proj-b', status: 'idle' });
         useSessionStore.setState({ sessions: [sessA, sessB] });

--- a/apps/web/src/stores/__tests__/useTerminalStore.test.ts
+++ b/apps/web/src/stores/__tests__/useTerminalStore.test.ts
@@ -32,7 +32,7 @@ const initialState = {
   letterSpacing: 0,
   cursorStyle: 'block' as const,
   cursorBlink: true,
-  scrollback: 10000,
+  scrollback: 3000,
   terminalThemeName: 'tokyonight' as const,
   focusedSessionId: null,
   addSlotRequestCounter: 0,
@@ -79,8 +79,8 @@ describe('useTerminalStore', () => {
       expect(useTerminalStore.getState().cursorBlink).toBe(true);
     });
 
-    it('has default scrollback of 10000', () => {
-      expect(useTerminalStore.getState().scrollback).toBe(10000);
+    it('has default scrollback of 3000', () => {
+      expect(useTerminalStore.getState().scrollback).toBe(3000);
     });
 
     it('has default terminal theme of tokyonight', () => {
@@ -227,7 +227,7 @@ describe('useTerminalStore', () => {
       expect(state.letterSpacing).toBe(0);
       expect(state.cursorStyle).toBe('block');
       expect(state.cursorBlink).toBe(true);
-      expect(state.scrollback).toBe(10000);
+      expect(state.scrollback).toBe(3000);
       expect(state.terminalThemeName).toBe('tokyonight');
     });
 

--- a/apps/web/src/stores/__tests__/useUsageStore.test.ts
+++ b/apps/web/src/stores/__tests__/useUsageStore.test.ts
@@ -448,16 +448,16 @@ describe('useUsageStore', () => {
       expect(useUsageStore.getState().isStale()).toBe(true);
     });
 
-    it('returns true when lastFetched is older than 2 minutes', () => {
-      const threeMinutesAgo = Date.now() - 3 * 60 * 1000;
-      useUsageStore.setState({ lastFetched: threeMinutesAgo });
+    it('returns true when lastFetched is older than 16 minutes', () => {
+      const seventeenMinutesAgo = Date.now() - 17 * 60 * 1000;
+      useUsageStore.setState({ lastFetched: seventeenMinutesAgo });
 
       expect(useUsageStore.getState().isStale()).toBe(true);
     });
 
-    it('returns false when lastFetched is within 2 minutes', () => {
-      const oneMinuteAgo = Date.now() - 1 * 60 * 1000;
-      useUsageStore.setState({ lastFetched: oneMinuteAgo });
+    it('returns false when lastFetched is within 16 minutes', () => {
+      const tenMinutesAgo = Date.now() - 10 * 60 * 1000;
+      useUsageStore.setState({ lastFetched: tenMinutesAgo });
 
       expect(useUsageStore.getState().isStale()).toBe(false);
     });
@@ -468,10 +468,10 @@ describe('useUsageStore', () => {
       expect(useUsageStore.getState().isStale()).toBe(false);
     });
 
-    it('returns true when exactly at 2 minute boundary', () => {
-      // 2 minutes and 1ms ago should be stale
-      const justOverTwoMinutes = Date.now() - (2 * 60 * 1000 + 1);
-      useUsageStore.setState({ lastFetched: justOverTwoMinutes });
+    it('returns true when just past the 16 minute boundary', () => {
+      // 16 minutes and 1ms ago should be stale
+      const justOverSixteenMinutes = Date.now() - (16 * 60 * 1000 + 1);
+      useUsageStore.setState({ lastFetched: justOverSixteenMinutes });
 
       expect(useUsageStore.getState().isStale()).toBe(true);
     });
@@ -481,7 +481,7 @@ describe('useUsageStore', () => {
       expect(useUsageStore.getState().isStale()).toBe(false);
 
       // Advance past the stale threshold
-      vi.advanceTimersByTime(2 * 60 * 1000 + 1);
+      vi.advanceTimersByTime(16 * 60 * 1000 + 1);
       expect(useUsageStore.getState().isStale()).toBe(true);
     });
   });

--- a/apps/web/src/stores/useSessionStore.ts
+++ b/apps/web/src/stores/useSessionStore.ts
@@ -281,12 +281,17 @@ export const useSessionStore = create<SessionStore>()(
 
         updateSession: (sessionId, updates) => {
           logger.debug('updateSession', sessionId);
+          // NOTE: `lastActiveAt` is intentionally NOT bumped here. The
+          // backend stamps its own timestamp on the source session and
+          // ships it on the wire (see SessionService.updateStatus); the
+          // renderer never reads `lastActiveAt` for display, so bumping
+          // it on every store write was rotating the session reference
+          // and triggering downstream `useShallow` / React.memo
+          // re-renders for free.
           set(
             state => ({
               sessions: state.sessions.map(session =>
-                session.id === sessionId
-                  ? { ...session, ...updates, lastActiveAt: new Date() }
-                  : session
+                session.id === sessionId ? { ...session, ...updates } : session
               ),
             }),
             undefined,
@@ -306,9 +311,9 @@ export const useSessionStore = create<SessionStore>()(
           logger.debug('updateStatus', sessionId, status);
           set(
             state => {
-              const sessionExists = state.sessions.some(s => s.id === sessionId);
+              const session = state.sessions.find(s => s.id === sessionId);
 
-              if (!sessionExists) {
+              if (!session) {
                 // Buffer the status update for later
                 logger.debug('Buffering pending update for unknown session', sessionId);
                 const pending = state.pendingStatusUpdates[sessionId] ?? [];
@@ -331,22 +336,47 @@ export const useSessionStore = create<SessionStore>()(
                 };
               }
 
+              // Early-return if no UI-relevant field actually changed.
+              // The backend re-emits status events on every PTY tick, but
+              // most carry the same payload (idle→idle, working→working
+              // with unchanged elapsed text). Skipping the array spread
+              // here preserves the array reference and the per-session
+              // reference, so downstream `useShallow` selectors and
+              // React.memo'd TerminalCards don't fan out unnecessarily.
+              const nextMessage = message ?? session.statusMessage;
+              const branchChanged = branch !== undefined && branch !== session.branch;
+              const worktreeChanged =
+                worktreePath !== undefined && worktreePath !== session.worktreePath;
+              const baselineChanged =
+                baselineCommitHash !== undefined &&
+                baselineCommitHash !== session.baselineCommitHash;
+              if (
+                session.status === status &&
+                session.statusMessage === nextMessage &&
+                session.needsInputPrompt === needsInputPrompt &&
+                !branchChanged &&
+                !worktreeChanged &&
+                !baselineChanged
+              ) {
+                return state;
+              }
+
+              // `lastActiveAt` intentionally not bumped here — see
+              // `updateSession` for rationale.
               return {
-                sessions: state.sessions.map(session =>
-                  session.id === sessionId
+                sessions: state.sessions.map(s =>
+                  s.id === sessionId
                     ? {
-                        ...session,
+                        ...s,
                         status,
-                        // Only update statusMessage if a new message is provided
-                        statusMessage: message ?? session.statusMessage,
+                        statusMessage: nextMessage,
                         needsInputPrompt,
                         // Apply branch/worktreePath when present (Bug #4)
                         ...(branch !== undefined && { branch }),
                         ...(worktreePath !== undefined && { worktreePath }),
                         ...(baselineCommitHash !== undefined && { baselineCommitHash }),
-                        lastActiveAt: new Date(),
                       }
-                    : session
+                    : s
                 ),
               };
             },

--- a/apps/web/src/stores/useTerminalStore.ts
+++ b/apps/web/src/stores/useTerminalStore.ts
@@ -77,7 +77,7 @@ const COMMON_DEFAULTS = {
   letterSpacing: 0,
   cursorStyle: 'block' as CursorStyle,
   cursorBlink: true,
-  scrollback: 10000,
+  scrollback: 3000,
   terminalThemeName: 'tokyonight' as TerminalThemeName,
   editorProtocol: DEFAULT_EDITOR_PROTOCOL,
 };

--- a/apps/web/src/stores/useUsageStore.ts
+++ b/apps/web/src/stores/useUsageStore.ts
@@ -11,8 +11,13 @@ const logger = createLogger('UsageStore');
 /** Polling interval for usage data (15 minutes) */
 const USAGE_POLLING_INTERVAL = 15 * 60 * 1000;
 
-/** Data is considered stale after 2 minutes */
-const STALE_THRESHOLD = 2 * 60 * 1000;
+/**
+ * Data is considered stale after 16 minutes — the 15-minute polling
+ * interval plus a 1-minute jitter buffer for fetch latency. Previously
+ * 2 minutes, which made the store report stale for 13/15 of every cycle
+ * and prompted spurious manual refetches.
+ */
+const STALE_THRESHOLD = 16 * 60 * 1000;
 
 /** Module-level polling interval ID (non-serializable, kept out of reactive state) */
 let pollingIntervalId: ReturnType<typeof setInterval> | null = null;

--- a/packages/shared/src/constants/app.ts
+++ b/packages/shared/src/constants/app.ts
@@ -94,7 +94,7 @@ export const LOG_MAX_FILE_SIZE = 10 * 1024 * 1024;
 export const LOG_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 /** Log flush interval in milliseconds */
-export const LOG_FLUSH_INTERVAL_MS = 100;
+export const LOG_FLUSH_INTERVAL_MS = 500;
 
 /** Maximum buffered log entries before forced flush */
 export const LOG_BUFFER_MAX_ENTRIES = 50;


### PR DESCRIPTION
## Summary

Bundles **PR 4** (perf quick wins) and **PR 7** (test hardening Tier 2) from the master plan at `docs/chain/2026-05-08-omniscribe-master-plan.md`. PR 4 cuts session-store fan-out re-renders during streaming and lands four small perf hygiene wins. PR 7 fills the test coverage gaps that the master plan flagged as prerequisites for the upcoming architectural thread (PR 8+).

Mirrors the bundled-PR pattern from #304 (PRs 0–3). Linear history, conventional commits, no force-pushes.

## PR 4 — Performance quick wins

- **Session-store fan-out re-renders** — `updateStatus` early-returns on no-op; renderer-side `lastActiveAt` bump dropped; `mapToTerminalSessions` memoized via `WeakMap<FrontendSessionConfig, TerminalSession>` keyed on `(session, sessionNumber, customTitle)`. Target: TerminalCard renders/sec on unchanged sessions <1/s during streaming (down from 5–10/s). Manual DevTools verification still recommended before merge — the unit tests prove referential stability of selector outputs and mapper outputs but cannot measure live render rate.
- **`checkRebaseState` 4 git spawns → `existsSync`** — mirrors the existing `checkMergeState` pattern; saves ~80 ms per `getStatus()` call. Boundary check is worktree-aware.
- **xterm scrollback default 10K → 3K** — ~70% memory reduction at multi-session steady state.
- **`useUsageStore` polling/stale alignment** — `STALE_THRESHOLD_MS` raised from 2 min to 16 min so the 15-min poll cadence stops marking data stale on every cycle. Polling cadence preserved (cheaper than dropping to 2-min poll).
- **`LOG_FLUSH_INTERVAL_MS` 100 → 500** — log flush wakeup churn 10×/s → 2×/s.

## PR 7 — Test hardening (Tier 2)

- **TerminalGateway PAUSE_SAFETY_TIMEOUT_MS force-resume** — 2 new cases: force-resume after 15 s, drain-before-timeout cancels safety timer.
- **TerminalGateway MAX_INPUT_SIZE 1 MB rejection** — already covered at `terminal.gateway.spec.ts:373`; verified, no duplicate added.
- **`useSessionStore` fan-out stable-reference assertions** — `Object.is` checks for `selectActiveSessions` and `selectSessionsForProject`. Originally added `it.skip` pending PR 4; **unskipped in this bundle** since PR 4 is in the same branch. Both pass.
- **`SessionService.update` length-validation rejection branches** — 7 new cases (name / model / systemPrompt over-limit, at-limit acceptance, nonexistent, event emit, no-event-on-rejection).
- **`HealthService` zombie cleanup edge cases** — 5 new cases (never-output working session, undefined `lastActiveAt` on error, recently-errored, non-WORKING-non-IDLE statuses, CLEANUP reason propagation).

## Verification

- [x] `pnpm typecheck` clean (shared / plugin-api / providers / web / mcp-server / desktop)
- [x] `pnpm --filter @omniscribe/desktop test` — 1733 / 1733 pass (80 suites)
- [x] `pnpm --filter @omniscribe/web test` — 1462 tests, 1447 pass; 15 failures are pre-existing in `apps/web/src/lib/__tests__/utils-and-theme.test.ts` (vitest-jsdom `localStorage.clear is not a function` config issue, present on master baseline before this branch — not regressed by this PR)

## Test plan

- [ ] Pull and run `pnpm install && pnpm typecheck && pnpm test`
- [ ] Boot the app with multiple working sessions, confirm TerminalCard render counter stays <1/s on unchanged sessions during streaming (PR 4 cross-PR gate)
- [ ] Open Settings → Updates and confirm changelog still renders (touches Markdown lazy-load surface from PR #304)
- [ ] Open the diff panel on a dirty repo to confirm `getStatus()` still returns identical state (rebase detection unchanged)

## Master plan progress

After this PR merges: **PR 0, 1, 2, 3, 4, 7 done.** Remaining: PR 5 (perf medium — builds on PR 4's `git-status.service.ts`), PR 6 (bundle medium — risky, needs visual regression sweep), PR 8+ (architecture — DISCUSS before starting), PR 9 (long-tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added input validation for session properties with maximum length enforcement
  * Implemented automatic terminal resume mechanism for backpressure recovery

* **Improvements**
  * Enhanced UI rendering performance through improved caching and referential stability
  * Improved git rebase detection reliability
  * Better terminal backpressure handling and responsiveness
  * Updated usage data refresh behavior with new staleness threshold

* **Changes**
  * Reduced terminal scrollback buffer default size
  * Increased logging flush interval for better performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->