### PR TITLE
Hardening sweep: concurrency, persistence, and input-validation fixes

### DIFF
--- a/apps/desktop/src/main/ipc/store.spec.ts
+++ b/apps/desktop/src/main/ipc/store.spec.ts
@@ -219,6 +219,30 @@ describe('IPC:Store', () => {
       handlers['store:set'](mockEvent, 'workspace.preferences.extra', 'tiny');
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
+
+    // Regression: the renderer relies on this result to surface failures to the
+    // user instead of silently dropping persisted state.
+    it('returns { ok: true } on a successful write', () => {
+      const result = handlers['store:set'](mockEvent, 'preferences.theme', 'dark');
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('returns { ok: false, reason: "unauthorized" } for a blocked key', () => {
+      const result = handlers['store:set'](mockEvent, 'system.internal', 'value');
+      expect(result).toEqual({ ok: false, reason: 'unauthorized' });
+    });
+
+    it('returns { ok: false, reason: "oversize" } when the cap is exceeded', () => {
+      const result = handlers['store:set'](mockEvent, 'preferences.theme', 'x'.repeat(4096));
+      expect(result).toEqual({ ok: false, reason: 'oversize' });
+    });
+
+    it('returns { ok: false, reason: "unserializable" } for cyclic values', () => {
+      const cyclic: Record<string, unknown> = {};
+      cyclic.self = cyclic;
+      const result = handlers['store:set'](mockEvent, 'preferences.theme', cyclic);
+      expect(result).toEqual({ ok: false, reason: 'unserializable' });
+    });
   });
 
   // ================================================================

--- a/apps/desktop/src/main/ipc/store.ts
+++ b/apps/desktop/src/main/ipc/store.ts
@@ -112,6 +112,15 @@ const STORE_DEFAULT_CAP_BYTES = 4_194_304; // 4 MB hard ceiling for nested write
 type SizeCheckResult = 'ok' | 'oversize' | 'unserializable';
 
 /**
+ * Result of a `store:set`. Returned to the renderer so a rejected write
+ * (unauthorized key, size cap, unserializable value) surfaces to the user
+ * instead of silently dropping persisted state.
+ */
+export type StoreSetResult =
+  | { ok: true }
+  | { ok: false; reason: 'unauthorized' | 'oversize' | 'unserializable' };
+
+/**
  * Find the nearest registered size cap walking up the key tree.
  * Returns `[capKey, capBytes]` where `capKey` is the segment-prefix
  * that owns the cap (may equal `key`), or `undefined` if none.
@@ -223,21 +232,22 @@ export function registerStoreHandlers(): void {
     return store.get(key);
   });
 
-  ipcMain.handle('store:set', (_event, key: string, value: unknown) => {
+  ipcMain.handle('store:set', (_event, key: string, value: unknown): StoreSetResult => {
     if (!isKeyAllowed(key)) {
       logger.warn(`Blocked store:set for unauthorized key: ${key}`);
-      return;
+      return { ok: false, reason: 'unauthorized' };
     }
     const sizeCheck = checkSizeCap(key, value);
     if (sizeCheck === 'unserializable') {
       logger.warn(`Blocked store:set for "${key}" — value is not JSON-serializable`);
-      return;
+      return { ok: false, reason: 'unserializable' };
     }
     if (sizeCheck === 'oversize') {
       logger.warn(`Blocked store:set for "${key}" — value exceeds size cap`);
-      return;
+      return { ok: false, reason: 'oversize' };
     }
     store.set(key, value);
+    return { ok: true };
   });
 
   ipcMain.handle('store:delete', (_event, key: string) => {

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -21,7 +21,10 @@ export interface ElectronAPI {
   };
   store: {
     get: <T>(key: string) => Promise<T | undefined>;
-    set: <T>(key: string, value: T) => Promise<void>;
+    set: <T>(
+      key: string,
+      value: T
+    ) => Promise<{ ok: boolean; reason?: 'unauthorized' | 'oversize' | 'unserializable' }>;
     delete: (key: string) => Promise<void>;
     clear: () => Promise<void>;
   };

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -104,8 +104,8 @@ export function initializeAutoUpdater(
     let isDowngrade = false;
     try {
       isDowngrade = semver.lt(info.version, app.getVersion());
-    } catch {
-      logger.warn(`Could not compare versions: ${info.version} vs ${app.getVersion()}`);
+    } catch (error) {
+      logger.warn(`Could not compare versions: ${info.version} vs ${app.getVersion()}`, error);
     }
     mainWindow.webContents.send('updater:update-available', {
       version: info.version,

--- a/apps/desktop/src/modules/git/git-diff.service.spec.ts
+++ b/apps/desktop/src/modules/git/git-diff.service.spec.ts
@@ -22,6 +22,7 @@ describe('GitDiffService', () => {
           provide: GitStatusService,
           useValue: {
             getStatus: jest.fn(),
+            getUntrackedFiles: jest.fn().mockResolvedValue([]),
           },
         },
       ],
@@ -412,18 +413,6 @@ describe('GitDiffService', () => {
       ].join('\n');
 
       gitBase.execGit.mockResolvedValueOnce({ stdout: rawDiff, stderr: '' });
-      gitStatus.getStatus.mockResolvedValueOnce({
-        isRepo: true,
-        isClean: true,
-        staged: [],
-        unstaged: [],
-        untracked: [],
-        hasConflicts: false,
-        isRebasing: false,
-        isMerging: false,
-        stashCount: 0,
-      });
-
       const result = await service.getDiff('/repo');
 
       expect(result.files).toHaveLength(1);
@@ -439,18 +428,6 @@ describe('GitDiffService', () => {
 
     it('should use provided baseCommit ref', async () => {
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      gitStatus.getStatus.mockResolvedValueOnce({
-        isRepo: true,
-        isClean: true,
-        staged: [],
-        unstaged: [],
-        untracked: [],
-        hasConflicts: false,
-        isRebasing: false,
-        isMerging: false,
-        stashCount: 0,
-      });
-
       await service.getDiff('/repo', 'abc123');
 
       expect(gitBase.execGit).toHaveBeenCalledWith('/repo', [
@@ -465,18 +442,6 @@ describe('GitDiffService', () => {
       gitBase.execGit
         .mockRejectedValueOnce(new Error('bad ref'))
         .mockResolvedValueOnce({ stdout: '', stderr: '' });
-      gitStatus.getStatus.mockResolvedValueOnce({
-        isRepo: true,
-        isClean: true,
-        staged: [],
-        unstaged: [],
-        untracked: [],
-        hasConflicts: false,
-        isRebasing: false,
-        isMerging: false,
-        stashCount: 0,
-      });
-
       await service.getDiff('/repo');
 
       // First call fails, second call is the fallback
@@ -493,18 +458,6 @@ describe('GitDiffService', () => {
       gitBase.execGit
         .mockRejectedValueOnce(new Error('bad ref'))
         .mockRejectedValueOnce(new Error('no index'));
-      gitStatus.getStatus.mockResolvedValueOnce({
-        isRepo: true,
-        isClean: true,
-        staged: [],
-        unstaged: [],
-        untracked: [],
-        hasConflicts: false,
-        isRebasing: false,
-        isMerging: false,
-        stashCount: 0,
-      });
-
       const result = await service.getDiff('/repo');
 
       expect(result.files).toHaveLength(0);
@@ -518,26 +471,16 @@ describe('GitDiffService', () => {
       const result = await service.getDiff('/repo', undefined, false);
 
       expect(result.files).toHaveLength(0);
-      // getStatus should not be called when includeUntracked=false
-      expect(gitStatus.getStatus).not.toHaveBeenCalled();
+      // The untracked lookup should be skipped when includeUntracked=false
+      expect(gitStatus.getUntrackedFiles).not.toHaveBeenCalled();
     });
 
     it('should generate synthetic diffs for untracked text files', async () => {
       // Main diff returns nothing
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
-      // getStatus returns untracked files
-      gitStatus.getStatus.mockResolvedValueOnce({
-        isRepo: true,
-        isClean: false,
-        staged: [],
-        unstaged: [],
-        untracked: ['newfile.ts'],
-        hasConflicts: false,
-        isRebasing: false,
-        isMerging: false,
-        stashCount: 0,
-      });
+      // untracked file present
+      gitStatus.getUntrackedFiles.mockResolvedValueOnce(['newfile.ts']);
 
       // Synthetic diff for untracked file
       const syntheticDiff = [
@@ -561,17 +504,7 @@ describe('GitDiffService', () => {
     it('should create binary marker for untracked binary extension files', async () => {
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
-      gitStatus.getStatus.mockResolvedValueOnce({
-        isRepo: true,
-        isClean: false,
-        staged: [],
-        unstaged: [],
-        untracked: ['photo.png'],
-        hasConflicts: false,
-        isRebasing: false,
-        isMerging: false,
-        stashCount: 0,
-      });
+      gitStatus.getUntrackedFiles.mockResolvedValueOnce(['photo.png']);
 
       const result = await service.getDiff('/repo');
 
@@ -589,17 +522,7 @@ describe('GitDiffService', () => {
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
       const binaryFiles = ['a.jpg', 'b.wasm', 'c.exe', 'd.pdf', 'e.zip'];
-      gitStatus.getStatus.mockResolvedValueOnce({
-        isRepo: true,
-        isClean: false,
-        staged: [],
-        unstaged: [],
-        untracked: binaryFiles,
-        hasConflicts: false,
-        isRebasing: false,
-        isMerging: false,
-        stashCount: 0,
-      });
+      gitStatus.getUntrackedFiles.mockResolvedValueOnce(binaryFiles);
 
       const result = await service.getDiff('/repo');
 
@@ -612,17 +535,7 @@ describe('GitDiffService', () => {
     it('should handle untracked file without extension as non-binary', async () => {
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
-      gitStatus.getStatus.mockResolvedValueOnce({
-        isRepo: true,
-        isClean: false,
-        staged: [],
-        unstaged: [],
-        untracked: ['Makefile'],
-        hasConflicts: false,
-        isRebasing: false,
-        isMerging: false,
-        stashCount: 0,
-      });
+      gitStatus.getUntrackedFiles.mockResolvedValueOnce(['Makefile']);
 
       // Synthetic diff for the file
       const syntheticDiff = [
@@ -641,13 +554,13 @@ describe('GitDiffService', () => {
       expect(result.files[0].isBinary).toBeFalsy();
     });
 
-    it('should handle getStatus failure gracefully for untracked files', async () => {
+    it('should handle untracked-file lookup failure gracefully', async () => {
       gitBase.execGit.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      gitStatus.getStatus.mockRejectedValueOnce(new Error('git status failed'));
+      gitStatus.getUntrackedFiles.mockRejectedValueOnce(new Error('git ls-files failed'));
 
       const result = await service.getDiff('/repo');
 
-      // Should return empty when status fails
+      // Should return empty when the untracked lookup fails
       expect(result.files).toHaveLength(0);
     });
 
@@ -672,18 +585,6 @@ describe('GitDiffService', () => {
       ].join('\n');
 
       gitBase.execGit.mockResolvedValueOnce({ stdout: rawDiff, stderr: '' });
-      gitStatus.getStatus.mockResolvedValueOnce({
-        isRepo: true,
-        isClean: false,
-        staged: [],
-        unstaged: [],
-        untracked: [],
-        hasConflicts: false,
-        isRebasing: false,
-        isMerging: false,
-        stashCount: 0,
-      });
-
       const result = await service.getDiff('/repo');
 
       expect(result.totalAdditions).toBe(1);

--- a/apps/desktop/src/modules/git/git-diff.service.spec.ts
+++ b/apps/desktop/src/modules/git/git-diff.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { GitDiffService } from './git-diff.service';
 import { GitBaseService } from './git-base.service';
 import { GitStatusService } from './git-status.service';
+import { createGitStatusServiceMock } from '../../../test/mocks';
 
 describe('GitDiffService', () => {
   let service: GitDiffService;
@@ -20,10 +21,7 @@ describe('GitDiffService', () => {
         },
         {
           provide: GitStatusService,
-          useValue: {
-            getStatus: jest.fn(),
-            getUntrackedFiles: jest.fn().mockResolvedValue([]),
-          },
+          useValue: createGitStatusServiceMock(),
         },
       ],
     }).compile();

--- a/apps/desktop/src/modules/git/git-diff.service.ts
+++ b/apps/desktop/src/modules/git/git-diff.service.ts
@@ -239,8 +239,9 @@ export class GitDiffService {
 
   private async getUntrackedFiles(projectPath: string): Promise<string[]> {
     try {
-      const status = await this.gitStatus.getStatus(projectPath);
-      return status.untracked;
+      // Lightweight: only the untracked set is needed here, so avoid the full
+      // status scan (branch/rebase/merge/stash) that getStatus() would run.
+      return await this.gitStatus.getUntrackedFiles(projectPath);
     } catch {
       return [];
     }

--- a/apps/desktop/src/modules/git/git-status.service.spec.ts
+++ b/apps/desktop/src/modules/git/git-status.service.spec.ts
@@ -353,6 +353,28 @@ describe('GitStatusService', () => {
     });
   });
 
+  describe('getUntrackedFiles', () => {
+    it('lists untracked files via a single ls-files spawn', async () => {
+      gitBase.execGit.mockResolvedValue({ stdout: 'a.ts\nsub/b.ts\n', stderr: '' });
+
+      const result = await service.getUntrackedFiles('/repo');
+
+      expect(result).toEqual(['a.ts', 'sub/b.ts']);
+      expect(gitBase.execGit).toHaveBeenCalledTimes(1);
+      expect(gitBase.execGit).toHaveBeenCalledWith('/repo', [
+        'ls-files',
+        '--others',
+        '--exclude-standard',
+      ]);
+    });
+
+    it('returns an empty array when there are no untracked files', async () => {
+      gitBase.execGit.mockResolvedValue({ stdout: '', stderr: '' });
+
+      expect(await service.getUntrackedFiles('/repo')).toEqual([]);
+    });
+  });
+
   describe('parseStatusCode', () => {
     it('should parse M as modified', () => {
       expect(service.parseStatusCode('M')).toBe('modified');

--- a/apps/desktop/src/modules/git/git-status.service.ts
+++ b/apps/desktop/src/modules/git/git-status.service.ts
@@ -169,6 +169,20 @@ export class GitStatusService {
   }
 
   /**
+   * List untracked files (respecting .gitignore). Lightweight alternative to
+   * getStatus() when only the untracked set is needed — one git spawn instead
+   * of the full branch/rebase/merge/stash scan.
+   */
+  async getUntrackedFiles(repoPath: string): Promise<string[]> {
+    const { stdout } = await this.gitBase.execGit(repoPath, [
+      'ls-files',
+      '--others',
+      '--exclude-standard',
+    ]);
+    return stdout.split('\n').filter(Boolean);
+  }
+
+  /**
    * Parse git status code to GitFileStatus
    */
   parseStatusCode(code: string): GitFileStatus {

--- a/apps/desktop/src/modules/git/git-status.service.ts
+++ b/apps/desktop/src/modules/git/git-status.service.ts
@@ -179,7 +179,7 @@ export class GitStatusService {
       '--others',
       '--exclude-standard',
     ]);
-    return stdout.split('\n').filter(Boolean);
+    return stdout.split(/\r?\n/).filter(Boolean);
   }
 
   /**

--- a/apps/desktop/src/modules/git/worktree.service.spec.ts
+++ b/apps/desktop/src/modules/git/worktree.service.spec.ts
@@ -155,6 +155,41 @@ describe('WorktreeService', () => {
       ]);
     });
 
+    // Regression: concurrent prepare() on the same repo must serialize, or the
+    // list -> probe -> `worktree add` sequences race on git's index/worktree locks.
+    it('serializes concurrent prepare() calls on the same repo', async () => {
+      let abbrevRefCalls = 0;
+      let releaseFirst: (() => void) | undefined;
+      const gate = new Promise<void>(resolve => {
+        releaseFirst = resolve;
+      });
+
+      mockGitBase.execGit.mockImplementation(async (_repo: string, args: string[]) => {
+        if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
+          abbrevRefCalls++;
+          // Hold the first call (the lock holder) until released.
+          if (abbrevRefCalls === 1) await gate;
+          return { stdout: 'main\n', stderr: '' };
+        }
+        // worktree list / rev-parse --verify / worktree add all succeed.
+        return { stdout: '', stderr: '' };
+      });
+
+      const pA = service.prepare('/repo', 'feat-a');
+      const pB = service.prepare('/repo', 'feat-b');
+
+      // Flush microtasks: A is parked inside the lock; B must be queued behind
+      // the mutex and not have started its own getCurrentBranch yet.
+      await new Promise(resolve => setImmediate(resolve));
+      expect(abbrevRefCalls).toBe(1);
+
+      releaseFirst?.();
+      await Promise.all([pA, pB]);
+
+      // B only ran after A released the lock.
+      expect(abbrevRefCalls).toBe(2);
+    });
+
     it('should create a new branch with worktree when branch does not exist', async () => {
       // getCurrentBranch
       mockGitBase.execGit.mockResolvedValueOnce({ stdout: 'main\n', stderr: '' });

--- a/apps/desktop/src/modules/git/worktree.service.ts
+++ b/apps/desktop/src/modules/git/worktree.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Mutex } from 'async-mutex';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -62,7 +63,27 @@ function sanitizeBranchForPath(branch: string): string | null {
 export class WorktreeService {
   private readonly logger = createLogger('WorktreeService');
 
+  /**
+   * Per-repo locks. Worktree mutations (`prepare`/`cleanup`) for the same repo
+   * must be serialized: git serializes index/worktree changes via on-disk locks,
+   * so concurrent operations race into cryptic "already exists / locked" errors
+   * or a silent `--detach` fallback that changes the session's branch semantics.
+   * Keyed by normalized projectPath; intentionally never pruned (bounded by the
+   * number of open repos, and dropping a lock mid-flight would defeat it).
+   */
+  private readonly repoLocks = new Map<string, Mutex>();
+
   constructor(private readonly gitBase: GitBaseService) {}
+
+  private getRepoMutex(projectPath: string): Mutex {
+    const key = normalizePath(projectPath);
+    let mutex = this.repoLocks.get(key);
+    if (!mutex) {
+      mutex = new Mutex();
+      this.repoLocks.set(key, mutex);
+    }
+    return mutex;
+  }
 
   /**
    * Compute the worktree path for a given project, branch, and location preference
@@ -119,6 +140,23 @@ export class WorktreeService {
       return null;
     }
 
+    // Serialize worktree mutations per repo to avoid git index/worktree lock races.
+    return this.getRepoMutex(projectPath).runExclusive(() =>
+      this.prepareLocked(projectPath, branch, location, currentBranchOverride)
+    );
+  }
+
+  /**
+   * Internal worktree preparation. Runs while holding the per-repo lock so the
+   * list -> branch-probe -> `worktree add` sequence is atomic against other
+   * sessions targeting the same repo.
+   */
+  private async prepareLocked(
+    projectPath: string,
+    branch: string,
+    location: WorktreeLocation,
+    currentBranchOverride?: string
+  ): Promise<string | null> {
     // Use provided currentBranch to avoid redundant git calls (Bug #8: TOCTOU race)
     let currentBranch: string;
     if (currentBranchOverride) {
@@ -271,19 +309,22 @@ export class WorktreeService {
   async cleanup(projectPath: string, worktreePath: string): Promise<void> {
     this.validateWorktreePath(projectPath, worktreePath);
     this.logger.info(`Cleaning up worktree at ${worktreePath}`);
-    // Remove the worktree
-    try {
-      await this.gitBase.execGit(projectPath, ['worktree', 'remove', worktreePath, '--force']);
-    } catch (error) {
-      this.logger.warn(`git worktree remove failed for ${worktreePath}`, error);
-      // If git worktree remove fails, try manual cleanup
+    // Serialize against prepare()/other cleanups on the same repo (git lock races).
+    await this.getRepoMutex(projectPath).runExclusive(async () => {
+      // Remove the worktree
       try {
-        await fs.rm(worktreePath, { recursive: true, force: true });
-        await this.gitBase.execGit(projectPath, ['worktree', 'prune']);
-      } catch (innerError) {
-        this.logger.warn(`Manual worktree cleanup failed for ${worktreePath}:`, innerError);
+        await this.gitBase.execGit(projectPath, ['worktree', 'remove', worktreePath, '--force']);
+      } catch (error) {
+        this.logger.warn(`git worktree remove failed for ${worktreePath}`, error);
+        // If git worktree remove fails, try manual cleanup
+        try {
+          await fs.rm(worktreePath, { recursive: true, force: true });
+          await this.gitBase.execGit(projectPath, ['worktree', 'prune']);
+        } catch (innerError) {
+          this.logger.warn(`Manual worktree cleanup failed for ${worktreePath}:`, innerError);
+        }
       }
-    }
+    });
   }
 
   /**

--- a/apps/desktop/src/modules/mcp/mcp-status-server.service.spec.ts
+++ b/apps/desktop/src/modules/mcp/mcp-status-server.service.spec.ts
@@ -292,6 +292,45 @@ describe('McpStatusServerService - Request Handling', () => {
     });
   });
 
+  // Regression: the /status body is untrusted loopback input. A forged or
+  // malformed payload must be rejected (400) and must NOT emit a session event.
+  it('should return 400 and not emit for an invalid state value', async () => {
+    sessionRegistry.getProjectPath.mockReturnValue('/project');
+
+    await initService();
+
+    const payload = JSON.stringify({
+      sessionId: 'session-1',
+      instanceId: 'test-uuid-1234',
+      state: 'hacked', // not a SessionStatusState
+      timestamp: new Date().toISOString(),
+    });
+
+    const { res } = simulateRequest('POST', '/status', payload);
+
+    expect(res.writeHead as jest.Mock).toHaveBeenCalledWith(400, {
+      'Content-Type': 'application/json',
+    });
+    expect(eventEmitter.emit).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 and not emit for a status payload missing sessionId', async () => {
+    await initService();
+
+    const payload = JSON.stringify({
+      instanceId: 'test-uuid-1234',
+      state: 'working',
+      timestamp: new Date().toISOString(),
+    });
+
+    const { res } = simulateRequest('POST', '/status', payload);
+
+    expect(res.writeHead as jest.Mock).toHaveBeenCalledWith(400, {
+      'Content-Type': 'application/json',
+    });
+    expect(eventEmitter.emit).not.toHaveBeenCalled();
+  });
+
   it('should reject status update with wrong instance ID', async () => {
     await initService();
 
@@ -494,6 +533,26 @@ describe('McpStatusServerService - Request Handling', () => {
       const responseBody = JSON.parse((res.end as jest.Mock).mock.calls[0][0]);
       expect(responseBody.accepted).toBe(false);
       expect(responseBody.reason).toBe('unknown_session');
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 and not emit for a malformed task item', async () => {
+      sessionRegistry.getProjectPath.mockReturnValue('/project');
+
+      await initService();
+
+      const payload = JSON.stringify({
+        sessionId: 'session-1',
+        instanceId: 'test-uuid-1234',
+        tasks: [{ id: 'task-1', subject: 'Do something', status: 'bogus-status' }],
+        timestamp: new Date().toISOString(),
+      });
+
+      const { res } = simulateRequest('POST', '/tasks', payload);
+
+      expect(res.writeHead as jest.Mock).toHaveBeenCalledWith(400, {
+        'Content-Type': 'application/json',
+      });
       expect(eventEmitter.emit).not.toHaveBeenCalled();
     });
 

--- a/apps/desktop/src/modules/mcp/mcp-status-server.service.ts
+++ b/apps/desktop/src/modules/mcp/mcp-status-server.service.ts
@@ -10,10 +10,80 @@ import {
   TasksPayload,
   SessionStatusState,
   SessionTasksUpdate,
+  TaskItem,
+  TaskStatus,
   createLogger,
 } from '@omniscribe/shared';
 import { InternalSessionEvents } from '../shared/events';
 import { McpSessionRegistryService } from './services/mcp-session-registry.service';
+
+/**
+ * The status server listens on a loopback HTTP port that any local process can
+ * reach, so payloads are untrusted input. Validate them field-by-field before
+ * emitting internal events that drive session state — a forged `state` must not
+ * flow through as a `SessionStatusState`.
+ */
+const SESSION_STATES: readonly SessionStatusState[] = [
+  'idle',
+  'working',
+  'planning',
+  'needs_input',
+  'finished',
+  'error',
+];
+const TASK_STATUSES: readonly TaskStatus[] = ['pending', 'in_progress', 'completed'];
+
+function asRecord(raw: unknown): Record<string, unknown> | null {
+  return typeof raw === 'object' && raw !== null ? (raw as Record<string, unknown>) : null;
+}
+
+function parseStatusPayload(raw: unknown): StatusPayload | null {
+  const p = asRecord(raw);
+  if (!p) return null;
+  if (typeof p.sessionId !== 'string' || p.sessionId.length === 0) return null;
+  if (typeof p.instanceId !== 'string') return null;
+  if (typeof p.state !== 'string' || !SESSION_STATES.includes(p.state as SessionStatusState)) {
+    return null;
+  }
+  if (p.message !== undefined && typeof p.message !== 'string') return null;
+  if (p.needsInputPrompt !== undefined && typeof p.needsInputPrompt !== 'string') return null;
+  return {
+    sessionId: p.sessionId,
+    instanceId: p.instanceId,
+    state: p.state as SessionStatusState,
+    message: p.message as string | undefined,
+    needsInputPrompt: p.needsInputPrompt as string | undefined,
+    timestamp: typeof p.timestamp === 'string' ? p.timestamp : '',
+  };
+}
+
+function parseTasksPayload(raw: unknown): TasksPayload | null {
+  const p = asRecord(raw);
+  if (!p) return null;
+  if (typeof p.sessionId !== 'string' || p.sessionId.length === 0) return null;
+  if (typeof p.instanceId !== 'string') return null;
+  // A missing tasks field is tolerated (treated as an empty snapshot); a present
+  // one must be a well-formed array of valid task items.
+  const tasks: TaskItem[] = [];
+  if (p.tasks !== undefined) {
+    if (!Array.isArray(p.tasks)) return null;
+    for (const entry of p.tasks) {
+      const t = asRecord(entry);
+      if (!t) return null;
+      if (typeof t.id !== 'string' || typeof t.subject !== 'string') return null;
+      if (typeof t.status !== 'string' || !TASK_STATUSES.includes(t.status as TaskStatus)) {
+        return null;
+      }
+      tasks.push({ id: t.id, subject: t.subject, status: t.status as TaskStatus });
+    }
+  }
+  return {
+    sessionId: p.sessionId,
+    instanceId: p.instanceId,
+    tasks,
+    timestamp: typeof p.timestamp === 'string' ? p.timestamp : '',
+  };
+}
 
 /**
  * Session status event emitted for UI updates
@@ -179,25 +249,42 @@ export class McpStatusServerService implements OnModuleInit, OnModuleDestroy {
     });
 
     req.on('end', () => {
+      let raw: unknown;
       try {
-        const payload = JSON.parse(body);
-
-        // Route based on URL path
-        switch (req.url) {
-          case '/status':
-            this.handleStatusUpdate(payload as StatusPayload, res);
-            break;
-          case '/tasks':
-            this.handleTasksUpdate(payload as TasksPayload, res);
-            break;
-          default:
-            res.writeHead(404, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: 'Not found' }));
-        }
+        raw = JSON.parse(body);
       } catch (error) {
         this.logger.error('Invalid JSON payload:', error);
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        return;
+      }
+
+      // Route based on URL path. Validate the body against the expected
+      // contract before acting on it — this is an untrusted loopback endpoint.
+      switch (req.url) {
+        case '/status': {
+          const payload = parseStatusPayload(raw);
+          if (!payload) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Invalid status payload' }));
+            return;
+          }
+          this.handleStatusUpdate(payload, res);
+          break;
+        }
+        case '/tasks': {
+          const payload = parseTasksPayload(raw);
+          if (!payload) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Invalid tasks payload' }));
+            return;
+          }
+          this.handleTasksUpdate(payload, res);
+          break;
+        }
+        default:
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Not found' }));
       }
     });
 
@@ -245,7 +332,7 @@ export class McpStatusServerService implements OnModuleInit, OnModuleDestroy {
     // dependency between McpModule and SessionModule.
     this.eventEmitter.emit(InternalSessionEvents.MCP_STATUS_RECEIVED, {
       sessionId: payload.sessionId,
-      status: payload.state as SessionStatusState,
+      status: payload.state,
       message: payload.message,
       needsInputPrompt: payload.needsInputPrompt,
     });

--- a/apps/desktop/src/modules/plugin/__tests__/plugin-loader.service.spec.ts
+++ b/apps/desktop/src/modules/plugin/__tests__/plugin-loader.service.spec.ts
@@ -629,6 +629,39 @@ describe('PluginLoaderService', () => {
       expect(providers[0].activated).toBe(false);
     });
 
+    // Regression: a user who disabled a provider must stay disabled across
+    // restarts — the persisted choice wins over the definition's autoEnable.
+    it('restores a persisted disabled state over autoEnable=true', async () => {
+      const def = createValidDefinition();
+      def.autoEnable = true; // would normally register enabled
+      const module = await buildModule([def]);
+      const loader = module.get<PluginLoaderService>(PluginLoaderService);
+      const reg = module.get<PluginRegistryService>(PluginRegistryService);
+      const storage = module.get<PluginStorageService>(PluginStorageService);
+
+      // The user previously turned this provider off.
+      storage.setEnabledState(def.manifest.id, false);
+
+      await loader.onModuleInit();
+
+      expect(reg.listProviders()[0].enabled).toBe(false);
+    });
+
+    it('restores a persisted enabled state over autoEnable=false', async () => {
+      const def = createValidDefinition();
+      // autoEnable defaults to false (undefined)
+      const module = await buildModule([def]);
+      const loader = module.get<PluginLoaderService>(PluginLoaderService);
+      const reg = module.get<PluginRegistryService>(PluginRegistryService);
+      const storage = module.get<PluginStorageService>(PluginStorageService);
+
+      storage.setEnabledState(def.manifest.id, true);
+
+      await loader.onModuleInit();
+
+      expect(reg.listProviders()[0].enabled).toBe(true);
+    });
+
     it('should register plugin as disabled when autoEnable is false (default)', async () => {
       const def = createValidDefinition();
       // autoEnable defaults to false (undefined)

--- a/apps/desktop/src/modules/plugin/__tests__/plugin-storage.service.spec.ts
+++ b/apps/desktop/src/modules/plugin/__tests__/plugin-storage.service.spec.ts
@@ -158,4 +158,28 @@ describe('PluginStorageService', () => {
       expect(() => service.clearStore('nonexistent')).not.toThrow();
     });
   });
+
+  // Regression: provider enable/disable used to live only in memory and reset to
+  // autoEnable on every restart. The host store must persist the user's choice.
+  describe('enabled-state persistence', () => {
+    it('round-trips a persisted enabled state', () => {
+      service.setEnabledState('provider-codex', false);
+      expect(service.getEnabledState('provider-codex')).toBe(false);
+
+      service.setEnabledState('provider-codex', true);
+      expect(service.getEnabledState('provider-codex')).toBe(true);
+    });
+
+    it('returns undefined for a plugin the user never toggled', () => {
+      expect(service.getEnabledState('never-toggled')).toBeUndefined();
+    });
+
+    it('tracks multiple plugins independently', () => {
+      service.setEnabledState('provider-a', true);
+      service.setEnabledState('provider-b', false);
+
+      expect(service.getEnabledState('provider-a')).toBe(true);
+      expect(service.getEnabledState('provider-b')).toBe(false);
+    });
+  });
 });

--- a/apps/desktop/src/modules/plugin/__tests__/plugin.gateway.spec.ts
+++ b/apps/desktop/src/modules/plugin/__tests__/plugin.gateway.spec.ts
@@ -60,6 +60,7 @@ const mockLoaderService = {
   activateProvider: jest.fn().mockResolvedValue(true),
   deactivateProvider: jest.fn().mockResolvedValue(true),
   refreshCliDetection: jest.fn().mockResolvedValue(undefined),
+  persistEnabledState: jest.fn(),
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/modules/plugin/__tests__/plugin.gateway.spec.ts
+++ b/apps/desktop/src/modules/plugin/__tests__/plugin.gateway.spec.ts
@@ -132,6 +132,7 @@ describe('PluginGateway', () => {
 
       expect(result).toEqual({ success: true });
       expect(mockRegistryService.setEnabled).toHaveBeenCalledWith('test-mode', true);
+      expect(mockLoaderService.persistEnabledState).toHaveBeenCalledWith('test-mode', true);
       expect(mockLoaderService.activateProvider).toHaveBeenCalledWith('test-mode');
       expect(mockServer.emit).toHaveBeenCalledWith('plugin:provider-enabled', {
         aiMode: 'test-mode',
@@ -147,6 +148,7 @@ describe('PluginGateway', () => {
 
       expect(result).toEqual({ success: true });
       expect(mockRegistryService.setEnabled).toHaveBeenCalledWith('test-mode', false);
+      expect(mockLoaderService.persistEnabledState).toHaveBeenCalledWith('test-mode', false);
       expect(mockLoaderService.deactivateProvider).toHaveBeenCalledWith('test-mode');
       expect(mockLoaderService.activateProvider).not.toHaveBeenCalled();
       expect(mockServer.emit).toHaveBeenCalledWith('plugin:provider-enabled', {

--- a/apps/desktop/src/modules/plugin/plugin-loader.service.ts
+++ b/apps/desktop/src/modules/plugin/plugin-loader.service.ts
@@ -138,6 +138,16 @@ export class PluginLoaderService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
+   * Persist a provider's enabled state (keyed by plugin id) so the user's
+   * choice survives a restart. No-op if the aiMode is unknown.
+   */
+  persistEnabledState(aiMode: string, enabled: boolean): void {
+    const entry = this.registry.getProviderEntry(aiMode);
+    if (!entry) return;
+    this.storageService.setEnabledState(entry.manifest.id, enabled);
+  }
+
+  /**
    * Load a single plugin definition: validate manifest, instantiate plugin,
    * run CLI detection, and register the provider.
    */
@@ -202,8 +212,10 @@ export class PluginLoaderService implements OnModuleInit, OnModuleDestroy {
       cliStatus = { installed: false, error: msg };
     }
 
-    // Register the provider (honor autoEnable flag, default disabled)
-    const enabled = definition.autoEnable ?? false;
+    // Register the provider. Prefer the user's persisted choice over the
+    // definition's autoEnable default so enable/disable survives a restart.
+    const enabled =
+      this.storageService.getEnabledState(manifest.id) ?? definition.autoEnable ?? false;
     this.registry.registerProvider(
       {
         manifest,

--- a/apps/desktop/src/modules/plugin/plugin-storage.service.ts
+++ b/apps/desktop/src/modules/plugin/plugin-storage.service.ts
@@ -11,6 +11,34 @@ import { createLogger } from '@omniscribe/shared';
 export class PluginStorageService {
   private readonly logger = createLogger('PluginStorage');
   private stores = new Map<string, Store>();
+  /** Host-level store for cross-plugin state (e.g. user enable/disable choices). */
+  private hostStore: Store | undefined;
+
+  private getHostStore(): Store {
+    if (this.hostStore) {
+      return this.hostStore;
+    }
+    const store = new Store({ name: 'plugin-host', defaults: {} });
+    this.hostStore = store;
+    return store;
+  }
+
+  /**
+   * Read a plugin's persisted enabled state. Returns undefined when the user has
+   * never toggled it, so the caller can fall back to the definition's autoEnable.
+   */
+  getEnabledState(pluginId: string): boolean | undefined {
+    const state = (this.getHostStore().get('enabledState', {}) ?? {}) as Record<string, boolean>;
+    return state[pluginId];
+  }
+
+  /** Persist a plugin's enabled state so it survives app restarts. */
+  setEnabledState(pluginId: string, enabled: boolean): void {
+    const store = this.getHostStore();
+    const state = (store.get('enabledState', {}) ?? {}) as Record<string, boolean>;
+    state[pluginId] = enabled;
+    store.set('enabledState', state);
+  }
 
   /** Get or create an isolated store for a plugin */
   getStore(pluginId: string): Store {

--- a/apps/desktop/src/modules/plugin/plugin.gateway.ts
+++ b/apps/desktop/src/modules/plugin/plugin.gateway.ts
@@ -86,6 +86,10 @@ export class PluginGateway implements OnGatewayInit {
         return { success: false, error: `No provider registered for aiMode: ${aiMode}` };
       }
 
+      // Persist the choice so it survives a restart (in-memory registry resets to
+      // autoEnable otherwise).
+      this.loaderService.persistEnabledState(aiMode, enabled);
+
       // If enabling, also activate the provider if not already activated
       if (enabled) {
         const entry = this.registryService.getProviderEntry(aiMode);

--- a/apps/desktop/src/modules/session/session-launcher.service.ts
+++ b/apps/desktop/src/modules/session/session-launcher.service.ts
@@ -164,17 +164,23 @@ export class SessionLauncherService {
         .execGit(worktreePath, ['rev-parse', 'HEAD'])
         .then(({ stdout }) => {
           const hash = stdout.trim();
-          if (hash) {
-            session.baselineCommitHash = hash;
-            this.logger.debug(`Captured baseline commit for ${sessionId}: ${hash}`);
-            // Broadcast to frontend so DiffPanel can use the baseline
-            this.eventEmitter.emit(InternalSessionEvents.STATUS, {
-              sessionId,
-              status: session.status,
-              message: session.statusMessage,
-              baselineCommitHash: hash,
-            });
+          if (!hash) return;
+          // Re-fetch: the session may have been removed during the async git call.
+          // Mutating/broadcasting a stale reference would resurrect a dropped session.
+          const current = this.sessionService.get(sessionId);
+          if (!current) {
+            this.logger.debug(`Skipping baseline for ${sessionId}: session no longer exists`);
+            return;
           }
+          current.baselineCommitHash = hash;
+          this.logger.debug(`Captured baseline commit for ${sessionId}: ${hash}`);
+          // Broadcast to frontend so DiffPanel can use the baseline
+          this.eventEmitter.emit(InternalSessionEvents.STATUS, {
+            sessionId,
+            status: current.status,
+            message: current.statusMessage,
+            baselineCommitHash: hash,
+          });
         })
         .catch(() => {
           // Not a git repo or no commits — baseline stays undefined

--- a/apps/desktop/src/modules/session/session.gateway.spec.ts
+++ b/apps/desktop/src/modules/session/session.gateway.spec.ts
@@ -503,6 +503,30 @@ describe('SessionGateway', () => {
       expect(result.error).toContain('Session limit reached');
       expect(result.idleSessions).toEqual([]);
     });
+
+    // Regression: a freshly created session has no terminal until several awaits
+    // later, so getRunningSessions() can't see in-flight launches. The in-flight
+    // counter must close that window so N concurrent creates can't over-spawn.
+    it('counts in-flight launches so concurrent creates cannot exceed the limit', async () => {
+      mockSessionService.getRunningSessions.mockReturnValue([]); // none have a terminal yet
+      // Launches never complete, so they stay in-flight (no terminal registered).
+      mockSessionLauncherService.launchSession.mockReturnValue(new Promise(() => {}));
+
+      // Fire MAX concurrent launches; each parks inside the in-flight window.
+      const inFlight = Array.from({ length: MAX_CONCURRENT_SESSIONS }, () =>
+        gateway.handleCreate(basePayload, client)
+      );
+      await new Promise(resolve => setImmediate(resolve));
+
+      // The next create must be rejected by the in-flight count, even though
+      // getRunningSessions() still reports zero active terminals.
+      const result = await gateway.handleCreate(basePayload, client);
+
+      expect(result.error).toContain('Session limit reached');
+      expect(mockSessionService.create).toHaveBeenCalledTimes(MAX_CONCURRENT_SESSIONS);
+
+      void inFlight; // intentionally left pending; the test asserts the rejection
+    });
   });
 
   // ========================================================================

--- a/apps/desktop/src/modules/session/session.gateway.spec.ts
+++ b/apps/desktop/src/modules/session/session.gateway.spec.ts
@@ -527,6 +527,18 @@ describe('SessionGateway', () => {
 
       void inFlight; // intentionally left pending; the test asserts the rejection
     });
+
+    // Regression: an uncaught throw would escape the handler and never invoke the
+    // Socket.io ack, hanging the renderer's request. It must resolve to { error }.
+    it('returns an error response instead of throwing when launch fails unexpectedly', async () => {
+      mockSessionService.create.mockImplementationOnce(() => {
+        throw new Error('boom while creating session');
+      });
+
+      const result = await gateway.handleCreate(basePayload, client);
+
+      expect(result.error).toContain('boom while creating session');
+    });
   });
 
   // ========================================================================

--- a/apps/desktop/src/modules/session/session.gateway.ts
+++ b/apps/desktop/src/modules/session/session.gateway.ts
@@ -78,6 +78,14 @@ interface UpdateSessionResponse {
 export class SessionGateway implements OnGatewayInit {
   private readonly logger = createLogger('SessionGateway');
 
+  /**
+   * Launches that have passed the concurrency check but not yet registered a
+   * terminal. A freshly created session has no terminalSessionId until several
+   * awaits later, so getRunningSessions() alone can't see it — without counting
+   * these, N concurrent creates all slip past the limit and over-spawn PTYs.
+   */
+  private launchesInFlight = 0;
+
   @WebSocketServer()
   server!: Server;
 
@@ -399,12 +407,14 @@ export class SessionGateway implements OnGatewayInit {
       return { error: pathError };
     }
 
-    // Check concurrency limit
+    // Check concurrency limit. Count in-flight launches that haven't registered
+    // a terminal yet (check + increment below are synchronous, so concurrent
+    // creates observe each other and can't all slip past the limit).
     const runningSessions = this.sessionService.getRunningSessions();
-    if (runningSessions.length >= MAX_CONCURRENT_SESSIONS) {
+    if (runningSessions.length + this.launchesInFlight >= MAX_CONCURRENT_SESSIONS) {
       const idleSessions = this.sessionService.getIdleSessions();
       this.logger.warn(
-        `[${errorPrefix}] Session limit reached: ${runningSessions.length}/${MAX_CONCURRENT_SESSIONS} running`
+        `[${errorPrefix}] Session limit reached: ${runningSessions.length}/${MAX_CONCURRENT_SESSIONS} running, ${this.launchesInFlight} launching`
       );
       return {
         error: `Session limit reached (${runningSessions.length}/${MAX_CONCURRENT_SESSIONS}). Close a session to start a new one.`,
@@ -412,16 +422,38 @@ export class SessionGateway implements OnGatewayInit {
       };
     }
 
-    const preferences = this.workspaceService.getPreferences();
-    const worktreeSettings: WorktreeSettings = preferences.worktree ?? DEFAULT_WORKTREE_SETTINGS;
-    const sessionSettings: SessionSettings = preferences.session ?? DEFAULT_SESSION_SETTINGS;
-    const skipPermissions = mode !== 'plain' && sessionSettings.skipPermissions ? true : undefined;
+    this.launchesInFlight++;
+    try {
+      const preferences = this.workspaceService.getPreferences();
+      const worktreeSettings: WorktreeSettings = preferences.worktree ?? DEFAULT_WORKTREE_SETTINGS;
+      const sessionSettings: SessionSettings = preferences.session ?? DEFAULT_SESSION_SETTINGS;
+      const skipPermissions =
+        mode !== 'plain' && sessionSettings.skipPermissions ? true : undefined;
 
-    const session = this.sessionService.create(mode, payload.projectPath, {
-      ...createOptions,
-      skipPermissions,
-    });
+      const session = this.sessionService.create(mode, payload.projectPath, {
+        ...createOptions,
+        skipPermissions,
+      });
 
+      return await this.runLaunch(client, payload, mode, session, worktreeSettings, errorPrefix);
+    } finally {
+      this.launchesInFlight--;
+    }
+  }
+
+  /**
+   * Worktree setup, launch, and terminal-room join for an already-created
+   * session. Extracted so launchSessionWithWorktree can hold the in-flight
+   * counter across the whole async body via try/finally.
+   */
+  private async runLaunch(
+    client: Socket,
+    payload: { projectPath: string; branch?: string; name?: string },
+    mode: AiMode,
+    session: BackendSessionConfig,
+    worktreeSettings: WorktreeSettings,
+    errorPrefix: string
+  ): Promise<CreateSessionResponse> {
     // Worktree setup (use currentBranch fallback when branch is absent)
     let worktreePath: string | null = null;
     let worktreeWarning: string | undefined;

--- a/apps/desktop/src/modules/session/session.gateway.ts
+++ b/apps/desktop/src/modules/session/session.gateway.ts
@@ -436,6 +436,13 @@ export class SessionGateway implements OnGatewayInit {
       });
 
       return await this.runLaunch(client, payload, mode, session, worktreeSettings, errorPrefix);
+    } catch (error) {
+      // Without this, an uncaught throw escapes the @SubscribeMessage handler;
+      // NestJS's WS filter never invokes the Socket.io ack, so the renderer hangs
+      // its full request timeout and surfaces an opaque error with no session.
+      const message = extractErrorMessage(error);
+      this.logger.error(`[${errorPrefix}] Unexpected error launching session:`, error);
+      return { error: message };
     } finally {
       this.launchesInFlight--;
     }

--- a/apps/desktop/src/modules/session/session.service.spec.ts
+++ b/apps/desktop/src/modules/session/session.service.spec.ts
@@ -679,6 +679,31 @@ describe('SessionService', () => {
     });
   });
 
+  describe('onMcpStatusReceived', () => {
+    it('applies the status when the session has a live terminal', () => {
+      const session = service.create('claude', '/project');
+      service.registerTerminal(session.id, 1, '/worktree');
+      terminalService.hasSession.mockReturnValue(true);
+
+      service.onMcpStatusReceived({ sessionId: session.id, status: 'working' });
+
+      expect(service.get(session.id)?.status).toBe('working');
+    });
+
+    // Regression: a late MCP POST from a dying subprocess must not flip a
+    // finished/error session back to "working" once its terminal is gone.
+    it('ignores a late MCP status when the terminal is gone (no resurrection)', () => {
+      const session = service.create('claude', '/project');
+      service.registerTerminal(session.id, 1, '/worktree');
+      // Terminal has exited — the PTY is no longer tracked.
+      terminalService.hasSession.mockReturnValue(false);
+
+      service.onMcpStatusReceived({ sessionId: session.id, status: 'working' });
+
+      expect(service.get(session.id)?.status).not.toBe('working');
+    });
+  });
+
   describe('stopSession', () => {
     it('should stop a running session', async () => {
       const session = service.create('claude', '/project');

--- a/apps/desktop/src/modules/session/session.service.ts
+++ b/apps/desktop/src/modules/session/session.service.ts
@@ -315,6 +315,17 @@ export class SessionService {
     message?: string;
     needsInputPrompt?: string;
   }): void {
+    // The MCP status server runs inside the CLI subprocess. If the terminal is
+    // gone, the subprocess is dead and this is a late/stale report — applying it
+    // would resurrect a finished/error session back to "working" (the transition
+    // table permits idle/error/finished -> working). Reject it.
+    if (!this.isSessionRunning(event.sessionId)) {
+      this.logger.debug(
+        `Ignoring MCP status for ${event.sessionId}: no active terminal (stale/late report)`
+      );
+      return;
+    }
+
     const updated = this.updateStatus(
       event.sessionId,
       event.status as SessionStatus,

--- a/apps/desktop/src/modules/workspace/workspace.service.spec.ts
+++ b/apps/desktop/src/modules/workspace/workspace.service.spec.ts
@@ -1,6 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { WorkspaceService } from './workspace.service';
 import type { ProjectTabDTO, QuickAction, SessionHistoryEntry } from '@omniscribe/shared';
+import * as fs from 'fs';
+
+jest.mock('electron', () => ({
+  app: { getPath: jest.fn(() => '/mock/userData') },
+}));
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(() => false),
+  copyFileSync: jest.fn(),
+}));
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
 
 // Mock electron-store with an in-memory implementation
 jest.mock('electron-store', () => {
@@ -62,6 +74,31 @@ describe('WorkspaceService', () => {
 
       const quickActions = service.getQuickActions();
       expect(quickActions.length).toBeGreaterThan(0);
+    });
+  });
+
+  // Regression: clearInvalidConfig wipes the entire workspace on a parse failure,
+  // so the bad file must be preserved first for recovery.
+  describe('backupCorruptStore', () => {
+    type WithBackup = { backupCorruptStore: () => void };
+
+    it('copies the workspace file to a timestamped backup when it exists', () => {
+      mockedFs.existsSync.mockReturnValue(true);
+
+      (service as unknown as WithBackup).backupCorruptStore();
+
+      expect(mockedFs.copyFileSync).toHaveBeenCalledWith(
+        '/mock/userData/workspace.json',
+        expect.stringMatching(/workspace\.corrupt-\d+\.json$/)
+      );
+    });
+
+    it('does nothing when there is no store file to back up', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      (service as unknown as WithBackup).backupCorruptStore();
+
+      expect(mockedFs.copyFileSync).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/modules/workspace/workspace.service.spec.ts
+++ b/apps/desktop/src/modules/workspace/workspace.service.spec.ts
@@ -7,10 +7,7 @@ jest.mock('electron', () => ({
   app: { getPath: jest.fn(() => '/mock/userData') },
 }));
 
-jest.mock('fs', () => ({
-  existsSync: jest.fn(() => false),
-  copyFileSync: jest.fn(),
-}));
+jest.mock('fs', () => require('../../../test/mocks/fs.mock').createFsMock());
 
 const mockedFs = fs as jest.Mocked<typeof fs>;
 

--- a/apps/desktop/src/modules/workspace/workspace.service.ts
+++ b/apps/desktop/src/modules/workspace/workspace.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import Store from 'electron-store';
-import { app } from 'electron';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -245,6 +244,9 @@ export class WorkspaceService implements OnModuleInit {
    */
   private backupCorruptStore(): void {
     try {
+      // Lazy require: WorkspaceService is transitively imported by many specs;
+      // a static `import from 'electron'` would force them all to mock electron.
+      const { app } = require('electron') as typeof import('electron');
       const userData = app.getPath('userData');
       const src = path.join(userData, 'workspace.json');
       if (!fs.existsSync(src)) {

--- a/apps/desktop/src/modules/workspace/workspace.service.ts
+++ b/apps/desktop/src/modules/workspace/workspace.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import Store from 'electron-store';
+import { app } from 'electron';
 import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
 import {
   QuickAction,
   ProjectTabDTO,
@@ -209,6 +212,9 @@ export class WorkspaceService implements OnModuleInit {
       this.logger.debug(`Store initialized at ${this.store.path}`);
     } catch (error) {
       this.logger.error('Failed to initialize workspace store, resetting to defaults:', error);
+      // Preserve the bad file before clearInvalidConfig wipes the user's entire
+      // workspace (tabs, history, preferences, capabilities) — best-effort.
+      this.backupCorruptStore();
       // Corruption or schema mismatch — clear and retry
       try {
         this.store = new Store<StoreSchema>({
@@ -230,6 +236,25 @@ export class WorkspaceService implements OnModuleInit {
         this.logger.error('Failed to initialize workspace store on retry:', retryError);
         throw retryError;
       }
+    }
+  }
+
+  /**
+   * Best-effort copy of the workspace store file before clearInvalidConfig
+   * wipes it, so a user can recover corrupted or hand-edited state.
+   */
+  private backupCorruptStore(): void {
+    try {
+      const userData = app.getPath('userData');
+      const src = path.join(userData, 'workspace.json');
+      if (!fs.existsSync(src)) {
+        return;
+      }
+      const backup = path.join(userData, `workspace.corrupt-${Date.now()}.json`);
+      fs.copyFileSync(src, backup);
+      this.logger.warn(`Backed up corrupt workspace store to ${backup}`);
+    } catch (backupError) {
+      this.logger.warn('Failed to back up corrupt workspace store', backupError);
     }
   }
 

--- a/apps/desktop/src/modules/workspace/workspace.service.ts
+++ b/apps/desktop/src/modules/workspace/workspace.service.ts
@@ -560,6 +560,14 @@ export class WorkspaceService implements OnModuleInit {
    * Prunes oldest entries when exceeding MAX_SESSION_HISTORY.
    */
   addSessionHistory(entry: SessionHistoryEntry): void {
+    // Guard: dedup keys on claudeSessionId, so an entry without one would collapse
+    // every other id-less entry via `undefined === undefined`. Callers must capture
+    // the id before recording history.
+    if (!entry.claudeSessionId) {
+      this.logger.warn('Ignoring session history entry with no claudeSessionId');
+      return;
+    }
+
     const history = this.store.get('sessionHistory', []);
 
     // Avoid duplicates (same claudeSessionId)

--- a/apps/desktop/test/mocks/fs.mock.ts
+++ b/apps/desktop/test/mocks/fs.mock.ts
@@ -1,0 +1,19 @@
+/**
+ * Mock for the Node `fs` module
+ *
+ * Only the synchronous calls the backend uses for corrupt-store recovery are
+ * stubbed (existsSync / copyFileSync). Because `jest.mock` is hoisted above
+ * imports, consume this from inside the factory callback:
+ *
+ *   jest.mock('fs', () => require('../../../test/mocks/fs.mock').createFsMock());
+ *
+ * Then assert/configure via the typed handle:
+ *   const mockedFs = fs as jest.Mocked<typeof fs>;
+ *   mockedFs.existsSync.mockReturnValue(true);
+ */
+export function createFsMock() {
+  return {
+    existsSync: jest.fn(() => false),
+    copyFileSync: jest.fn(),
+  };
+}

--- a/apps/desktop/test/mocks/git-status-service.mock.ts
+++ b/apps/desktop/test/mocks/git-status-service.mock.ts
@@ -1,0 +1,17 @@
+/**
+ * Mock for GitStatusService
+ *
+ * GitDiffService depends on GitStatusService (for untracked-file lookups when
+ * building diffs). Tests that exercise GitDiffService only need a thin stub of
+ * the status service, so this factory provides one with sensible defaults.
+ *
+ * Override per test as needed, e.g.:
+ *   const mock = createGitStatusServiceMock();
+ *   mock.getUntrackedFiles.mockResolvedValue(['a.ts']);
+ */
+export function createGitStatusServiceMock() {
+  return {
+    getStatus: jest.fn(),
+    getUntrackedFiles: jest.fn().mockResolvedValue([]),
+  };
+}

--- a/apps/desktop/test/mocks/index.ts
+++ b/apps/desktop/test/mocks/index.ts
@@ -2,3 +2,4 @@ export { MockPty, createNodePtyMock } from './node-pty.mock';
 export { MockStore, createElectronStoreMock } from './electron-store.mock';
 export { createExecMock, createChildProcessMock } from './child-process.mock';
 export type { ExecMockResult } from './child-process.mock';
+export { createGitStatusServiceMock } from './git-status-service.mock';

--- a/apps/desktop/test/mocks/index.ts
+++ b/apps/desktop/test/mocks/index.ts
@@ -3,3 +3,4 @@ export { MockStore, createElectronStoreMock } from './electron-store.mock';
 export { createExecMock, createChildProcessMock } from './child-process.mock';
 export type { ExecMockResult } from './child-process.mock';
 export { createGitStatusServiceMock } from './git-status-service.mock';
+export { createFsMock } from './fs.mock';

--- a/apps/web/src/components/sidebar/SidebarProjectItem.tsx
+++ b/apps/web/src/components/sidebar/SidebarProjectItem.tsx
@@ -145,7 +145,7 @@ export const SidebarProjectItem = React.memo(function SidebarProjectItem({
                   {...listeners}
                   role="tab"
                   aria-selected={isActive}
-                  tabIndex={isActive ? 0 : -1}
+                  tabIndex={0}
                   onClick={handleClick}
                   onKeyDown={handleKeyDown}
                   aria-label={label}
@@ -212,7 +212,7 @@ export const SidebarProjectItem = React.memo(function SidebarProjectItem({
           <div
             role="tab"
             aria-selected={isActive}
-            tabIndex={isActive ? 0 : -1}
+            tabIndex={0}
             onClick={handleClick}
             onKeyDown={handleKeyDown}
             className={cn(

--- a/apps/web/src/components/sidebar/SidebarProjectItem.tsx
+++ b/apps/web/src/components/sidebar/SidebarProjectItem.tsx
@@ -55,6 +55,18 @@ export const SidebarProjectItem = React.memo(function SidebarProjectItem({
     onSelect(id);
   }, [id, onSelect]);
 
+  // The sidebar uses a PointerSensor only (no KeyboardSensor), so these tab divs
+  // need their own keyboard activation to be reachable without a mouse.
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onSelect(id);
+      }
+    },
+    [id, onSelect]
+  );
+
   const handleClose = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -133,8 +145,11 @@ export const SidebarProjectItem = React.memo(function SidebarProjectItem({
                   {...listeners}
                   role="tab"
                   aria-selected={isActive}
+                  tabIndex={isActive ? 0 : -1}
                   onClick={handleClick}
-                  className="no-drag relative w-8 h-8 mx-auto cursor-pointer"
+                  onKeyDown={handleKeyDown}
+                  aria-label={label}
+                  className="no-drag relative w-8 h-8 mx-auto cursor-pointer rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:ring-offset-1 focus-visible:ring-offset-sidebar"
                 >
                   <div
                     className={cn(
@@ -197,7 +212,9 @@ export const SidebarProjectItem = React.memo(function SidebarProjectItem({
           <div
             role="tab"
             aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
             onClick={handleClick}
+            onKeyDown={handleKeyDown}
             className={cn(
               'no-drag group flex items-center gap-2 px-2 py-1.5 mx-1 rounded-lg cursor-pointer',
               'transition-colors duration-150 ease-out relative',

--- a/apps/web/src/components/terminal/TerminalSearchBar.tsx
+++ b/apps/web/src/components/terminal/TerminalSearchBar.tsx
@@ -106,6 +106,7 @@ export const TerminalSearchBar: React.FC<TerminalSearchBarProps> = ({
         onClick={onPrevious}
         className="p-0.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
         title="Previous (Shift+Enter)"
+        aria-label="Previous match"
       >
         <ChevronUp size={14} />
       </button>
@@ -115,6 +116,7 @@ export const TerminalSearchBar: React.FC<TerminalSearchBarProps> = ({
         onClick={onNext}
         className="p-0.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
         title="Next (Enter)"
+        aria-label="Next match"
       >
         <ChevronDown size={14} />
       </button>
@@ -124,6 +126,7 @@ export const TerminalSearchBar: React.FC<TerminalSearchBarProps> = ({
         onClick={onClose}
         className="p-0.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
         title="Close (Escape)"
+        aria-label="Close search"
       >
         <X size={14} />
       </button>

--- a/apps/web/src/lib/types/global.d.ts
+++ b/apps/web/src/lib/types/global.d.ts
@@ -23,7 +23,10 @@ interface ElectronAPI {
   };
   store: {
     get: <T>(key: string) => Promise<T | undefined>;
-    set: <T>(key: string, value: T) => Promise<void>;
+    set: <T>(
+      key: string,
+      value: T
+    ) => Promise<{ ok: boolean; reason?: 'unauthorized' | 'oversize' | 'unserializable' }>;
     delete: (key: string) => Promise<void>;
     clear: () => Promise<void>;
   };

--- a/apps/web/src/stores/useQuickActionStore.ts
+++ b/apps/web/src/stores/useQuickActionStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage, StateStorage } from 'zustand/middleware';
+import { toast } from 'sonner';
 import { devtools } from './utils/devtools';
 import { QuickAction, createLogger } from '@omniscribe/shared';
 import { createMemoizedSelector } from './utils';
@@ -159,7 +160,18 @@ const electronStorage: StateStorage = {
   setItem: async (name: string, value: string): Promise<void> => {
     logger.debug('Storage setItem:', name);
     if (typeof window !== 'undefined' && window.electronAPI?.store) {
-      await window.electronAPI.store.set(name, value);
+      const result = await window.electronAPI.store.set(name, value);
+      // A rejected write (size cap / unserializable / unauthorized) used to be a
+      // silent no-op, so quick actions appeared saved but vanished on reload.
+      if (result && result.ok === false) {
+        logger.error(`Failed to persist "${name}": ${result.reason}`);
+        toast.error('Quick actions could not be saved', {
+          description:
+            result.reason === 'oversize'
+              ? 'You have too many or too large quick actions to store.'
+              : 'Your latest quick-action changes were not persisted.',
+        });
+      }
     } else {
       // Fallback to localStorage for web-only mode
       localStorage.setItem(name, value);

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
       "undici": ">=7.24.0",
       "flatted": ">=3.4.2",
       "tar@>=6": ">=7.5.11",
-      "hono": ">=4.12.18 <5.0.0",
+      "hono": ">=4.12.21 <5.0.0",
       "fast-uri": ">=3.1.2 <4.0.0",
       "jest": ">=30.3.0 <30.4.0",
       "@hono/node-server": ">=1.19.13",
       "@xmldom/xmldom": ">=0.8.12 <0.9.0",
-      "axios": ">=1.15.0",
+      "axios": ">=1.16.0",
       "follow-redirects": ">=1.16.0",
       "lodash": ">=4.18.0",
       "handlebars": ">=4.7.9",
@@ -30,11 +30,14 @@
       "path-to-regexp@<1": ">=0.1.13 <0.2.0",
       "picomatch": ">=4.0.4",
       "file-type": ">=21.3.2",
-      "brace-expansion@>=5": ">=5.0.5",
+      "brace-expansion@>=5": ">=5.0.6",
       "yaml@>=2": ">=2.8.3",
       "@tootallnate/once": ">=3.0.1",
       "postcss": ">=8.5.10",
-      "ip-address": ">=10.1.1"
+      "ip-address": ">=10.1.1",
+      "ws": ">=8.20.1 <9.0.0",
+      "qs": ">=6.15.2",
+      "tmp": ">=0.2.7"
     }
   },
   "scripts": {

--- a/packages/plugins/provider-claude/src/__tests__/cli-command.service.spec.ts
+++ b/packages/plugins/provider-claude/src/__tests__/cli-command.service.spec.ts
@@ -34,7 +34,6 @@ jest.mock('@omniscribe/shared', () => {
 import { ClaudeCliCommandService } from '../services/cli-command.service';
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
-import * as path from 'path';
 import type { LaunchContext } from '@omniscribe/plugin-api';
 
 const mockedExecFileSync = execFileSync as jest.MockedFunction<typeof execFileSync>;
@@ -351,7 +350,8 @@ describe('ClaudeCliCommandService', () => {
         throw new Error('not found');
       });
 
-      const expectedPath = path.join(appData, 'npm', 'claude.cmd');
+      // The canonical getClaudeCliPaths() normalizes separators to forward slashes.
+      const expectedPath = 'C:/Users/test/AppData/Roaming/npm/claude.cmd';
       mockedExistsSync.mockImplementation((p: unknown) => {
         return p === expectedPath;
       });

--- a/packages/plugins/provider-claude/src/services/cli-command.service.ts
+++ b/packages/plugins/provider-claude/src/services/cli-command.service.ts
@@ -9,12 +9,11 @@
  * Pure TypeScript class with no NestJS dependencies.
  */
 
-import * as os from 'os';
-import * as path from 'path';
 import type { CliCommandConfig, LaunchContext } from '@omniscribe/plugin-api';
 import { createLogger } from '@omniscribe/shared';
 import { findCliCommandSync } from '@omniscribe/shared/node';
 import { OMNISCRIBE_SYSTEM_PROMPT } from './system-prompt';
+import { getClaudeCliPaths } from './cli-detection.service';
 
 const logger = createLogger('ClaudeCliCommand');
 
@@ -132,55 +131,8 @@ export class ClaudeCliCommandService {
    * to the bare 'claude' command if nothing is found.
    */
   resolveClaudeCommand(): string {
-    return findCliCommandSync('claude', this.getClaudeCliPaths(), logger);
-  }
-
-  /**
-   * Get common paths where Claude CLI might be installed.
-   */
-  private getClaudeCliPaths(): string[] {
-    const homeDir = os.homedir();
-
-    if (os.platform() === 'win32') {
-      const appData = process.env.APPDATA || path.join(homeDir, 'AppData', 'Roaming');
-      const localAppData = process.env.LOCALAPPDATA || path.join(homeDir, 'AppData', 'Local');
-
-      return [
-        // npm global installations
-        path.join(appData, 'npm', 'claude.cmd'),
-        path.join(appData, 'npm', 'claude'),
-        path.join(appData, '.npm-global', 'bin', 'claude.cmd'),
-        path.join(appData, '.npm-global', 'bin', 'claude'),
-        // Local bin
-        path.join(homeDir, '.local', 'bin', 'claude.exe'),
-        path.join(homeDir, '.local', 'bin', 'claude'),
-        // pnpm global
-        path.join(localAppData, 'pnpm', 'claude.cmd'),
-        path.join(localAppData, 'pnpm', 'claude'),
-        // Volta
-        path.join(homeDir, '.volta', 'bin', 'claude.exe'),
-      ];
-    }
-
-    // macOS and Linux paths
-    return [
-      // npm global installations
-      '/usr/local/bin/claude',
-      '/usr/bin/claude',
-      path.join(homeDir, '.npm-global', 'bin', 'claude'),
-      // Local bin
-      path.join(homeDir, '.local', 'bin', 'claude'),
-      // nvm installations
-      path.join(homeDir, '.nvm', 'versions', 'node', '*', 'bin', 'claude'),
-      // pnpm global
-      path.join(homeDir, 'Library', 'pnpm', 'claude'),
-      path.join(homeDir, '.local', 'share', 'pnpm', 'claude'),
-      // Homebrew
-      '/opt/homebrew/bin/claude',
-      // Volta
-      path.join(homeDir, '.volta', 'bin', 'claude'),
-      // Bun
-      path.join(homeDir, '.bun', 'bin', 'claude'),
-    ];
+    // Reuse the canonical path list from the detection service (incl. NVM/fnm
+    // dynamic paths) rather than maintaining a second, drift-prone copy.
+    return findCliCommandSync('claude', getClaudeCliPaths(), logger);
   }
 }

--- a/packages/plugins/provider-claude/src/services/cli-detection.service.ts
+++ b/packages/plugins/provider-claude/src/services/cli-detection.service.ts
@@ -21,6 +21,9 @@ import {
   isWindows,
   findCliInPath,
   findCliInLocalPaths,
+  getNvmBinPaths,
+  getFnmBinPaths,
+  getNvmWindowsCliPaths,
 } from '@omniscribe/shared/node';
 
 const logger = createLogger('ClaudeCliDetection');
@@ -178,26 +181,10 @@ export class ClaudeCliDetectionService {
 
   /**
    * Get common Claude CLI installation paths (cross-platform).
+   * Delegates to the standalone `getClaudeCliPaths()` function.
    */
   getClaudeCliPaths(): string[] {
-    const home = getHomeDir();
-
-    if (isWindows()) {
-      const appData = process.env['APPDATA'] || joinPaths(home, 'AppData/Roaming');
-      const localAppData = process.env['LOCALAPPDATA'] || joinPaths(home, 'AppData/Local');
-      return [
-        joinPaths(home, '.local/bin/claude.exe'),
-        joinPaths(appData, 'npm/claude.cmd'),
-        joinPaths(appData, 'npm/claude'),
-        joinPaths(localAppData, 'Programs/claude/claude.exe'),
-      ];
-    }
-
-    return [
-      joinPaths(home, '.local/bin/claude'),
-      '/usr/local/bin/claude',
-      joinPaths(home, '.npm-global/bin/claude'),
-    ];
+    return getClaudeCliPaths();
   }
 
   /**
@@ -232,4 +219,65 @@ export class ClaudeCliDetectionService {
       return false;
     }
   }
+}
+
+/**
+ * Get common Claude CLI installation paths across all platforms.
+ *
+ * Union of the standard locations, npm global, pnpm, Volta, Bun, Homebrew,
+ * and dynamically-resolved NVM/fnm bin paths.
+ *
+ * Standalone function so that the command service (synchronous path
+ * resolution) and the detection service share a single source of truth —
+ * a CLI found by detection must also be found at launch time.
+ */
+export function getClaudeCliPaths(): string[] {
+  const home = getHomeDir();
+
+  if (isWindows()) {
+    const appData = process.env['APPDATA'] || joinPaths(home, 'AppData/Roaming');
+    const localAppData = process.env['LOCALAPPDATA'] || joinPaths(home, 'AppData/Local');
+    return [
+      joinPaths(home, '.local/bin/claude.exe'),
+      joinPaths(home, '.local/bin/claude'),
+      joinPaths(appData, 'npm/claude.cmd'),
+      joinPaths(appData, 'npm/claude'),
+      joinPaths(appData, '.npm-global/bin/claude.cmd'),
+      joinPaths(appData, '.npm-global/bin/claude'),
+      // pnpm on Windows
+      joinPaths(localAppData, 'pnpm/claude.cmd'),
+      joinPaths(localAppData, 'pnpm/claude'),
+      // Volta on Windows
+      joinPaths(home, '.volta/bin/claude.exe'),
+      // Native installer
+      joinPaths(localAppData, 'Programs/claude/claude.exe'),
+      // NVM for Windows symlink paths
+      ...getNvmWindowsCliPaths('claude'),
+    ];
+  }
+
+  // macOS and Linux paths
+  const nvmBinPaths = getNvmBinPaths().map(binPath => joinPaths(binPath, 'claude'));
+  const fnmBinPaths = getFnmBinPaths().map(binPath => joinPaths(binPath, 'claude'));
+
+  return [
+    // Standard locations
+    joinPaths(home, '.local/bin/claude'),
+    '/usr/local/bin/claude',
+    '/usr/bin/claude',
+    joinPaths(home, '.npm-global/bin/claude'),
+    // Homebrew
+    '/opt/homebrew/bin/claude',
+    // Volta
+    joinPaths(home, '.volta/bin/claude'),
+    // pnpm global
+    joinPaths(home, 'Library/pnpm/claude'),
+    joinPaths(home, '.local/share/pnpm/claude'),
+    // Bun
+    joinPaths(home, '.bun/bin/claude'),
+    // NVM paths (dynamically resolved)
+    ...nvmBinPaths,
+    // fnm paths (dynamically resolved)
+    ...fnmBinPaths,
+  ];
 }

--- a/packages/plugins/provider-claude/src/services/usage-fetcher.service.ts
+++ b/packages/plugins/provider-claude/src/services/usage-fetcher.service.ts
@@ -46,6 +46,15 @@ interface NodePtyModule {
   spawn: (file: string, args: string[], options: IPtyForkOptions) => IPty;
 }
 
+// Timing for driving the Claude CLI PTY through trust/REPL prompts to the /usage output.
+// These are deliberate human-paced delays to let the interactive CLI settle between writes.
+const FETCH_TIMEOUT_MS = 45_000;
+const USAGE_OUTPUT_SETTLE_MS = 3_000; // wait for full usage output before sending ESC
+const FORCE_KILL_FALLBACK_MS = 2_000; // force-kill if ESC doesn't exit the REPL
+const TRUST_DIALOG_ENTER_MS = 1_000; // pause before approving the trust dialog
+const REPL_SETTLE_MS = 1_500; // let the REPL settle before sending /usage
+const AUTOCOMPLETE_CONFIRM_MS = 1_200; // second Enter to confirm any autocomplete
+
 /**
  * Claude Usage Fetcher Service.
  *
@@ -55,7 +64,7 @@ interface NodePtyModule {
  */
 export class ClaudeUsageFetcherService {
   private readonly logger = createLogger('ClaudeUsageFetcher');
-  private readonly timeout = 45000; // 45 second timeout
+  private readonly timeout = FETCH_TIMEOUT_MS;
   private readonly isWindows = os.platform() === 'win32';
   private readonly parser = new ClaudeUsageParserService();
 
@@ -221,14 +230,14 @@ export class ClaudeUsageFetcherService {
             if (!settled && ptyProcess) {
               ptyProcess.write('\x1b'); // Send escape key
 
-              // Fallback: force kill after 2s if ESC doesn't work
+              // Fallback: force kill if ESC doesn't work
               setTimeout(() => {
                 if (!settled && ptyProcess) {
                   this.killPtyProcess(ptyProcess);
                 }
-              }, 2000);
+              }, FORCE_KILL_FALLBACK_MS);
             }
-          }, 3000);
+          }, USAGE_OUTPUT_SETTLE_MS);
         }
 
         // Handle Trust Dialog
@@ -245,7 +254,7 @@ export class ClaudeUsageFetcherService {
             if (!settled && ptyProcess) {
               ptyProcess.write('\r');
             }
-          }, 1000);
+          }, TRUST_DIALOG_ENTER_MS);
         }
 
         // Detect REPL prompt and send /usage command
@@ -269,9 +278,9 @@ export class ClaudeUsageFetcherService {
                 if (!settled && ptyProcess) {
                   ptyProcess.write('\r');
                 }
-              }, 1200);
+              }, AUTOCOMPLETE_CONFIRM_MS);
             }
-          }, 1500);
+          }, REPL_SETTLE_MS);
         }
       });
 

--- a/packages/plugins/provider-codex/src/__tests__/cli-command.service.spec.ts
+++ b/packages/plugins/provider-codex/src/__tests__/cli-command.service.spec.ts
@@ -34,7 +34,6 @@ jest.mock('@omniscribe/shared', () => {
 import { CodexCliCommandService } from '../services/cli-command.service';
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
-import * as path from 'path';
 import type { LaunchContext } from '@omniscribe/plugin-api';
 
 const mockedExecFileSync = execFileSync as jest.MockedFunction<typeof execFileSync>;
@@ -306,7 +305,8 @@ describe('CodexCliCommandService', () => {
         throw new Error('not found');
       });
 
-      const expectedPath = path.join(appData, 'npm', 'codex.cmd');
+      // The canonical getCodexCliPaths() normalizes separators to forward slashes.
+      const expectedPath = 'C:/Users/test/AppData/Roaming/npm/codex.cmd';
       mockedExistsSync.mockImplementation((p: unknown) => {
         return p === expectedPath;
       });

--- a/packages/plugins/provider-codex/src/services/cli-command.service.ts
+++ b/packages/plugins/provider-codex/src/services/cli-command.service.ts
@@ -13,11 +13,10 @@
  * - No system prompt flags (Codex uses AGENTS.md and config)
  */
 
-import * as os from 'os';
-import * as path from 'path';
 import type { CliCommandConfig, LaunchContext } from '@omniscribe/plugin-api';
 import { createLogger } from '@omniscribe/shared';
 import { findCliCommandSync } from '@omniscribe/shared/node';
+import { getCodexCliPaths } from './cli-detection.service';
 
 const logger = createLogger('CodexCliCommand');
 
@@ -115,59 +114,8 @@ export class CodexCliCommandService {
    * to the bare 'codex' command if nothing is found.
    */
   resolveCodexCommand(): string {
-    return findCliCommandSync('codex', this.getCodexCliPaths(), logger);
-  }
-
-  /**
-   * Get common paths where Codex CLI might be installed.
-   *
-   * Covers standard locations, npm global, Volta, pnpm, Yarn,
-   * Homebrew, and Linuxbrew paths. NVM/fnm dynamic scanning is
-   * handled by the detection service (this uses static paths only
-   * for synchronous resolution).
-   */
-  private getCodexCliPaths(): string[] {
-    const homeDir = os.homedir();
-
-    if (os.platform() === 'win32') {
-      const appData = process.env['APPDATA'] || path.join(homeDir, 'AppData', 'Roaming');
-      const localAppData = process.env['LOCALAPPDATA'] || path.join(homeDir, 'AppData', 'Local');
-
-      return [
-        // Local bin
-        path.join(homeDir, '.local', 'bin', 'codex.exe'),
-        // npm global installations
-        path.join(appData, 'npm', 'codex.cmd'),
-        path.join(appData, 'npm', 'codex'),
-        path.join(appData, '.npm-global', 'bin', 'codex.cmd'),
-        path.join(appData, '.npm-global', 'bin', 'codex'),
-        // Volta
-        path.join(homeDir, '.volta', 'bin', 'codex.exe'),
-        // pnpm global
-        path.join(localAppData, 'pnpm', 'codex.cmd'),
-        path.join(localAppData, 'pnpm', 'codex'),
-      ];
-    }
-
-    // macOS and Linux paths
-    return [
-      // Standard locations
-      path.join(homeDir, '.local', 'bin', 'codex'),
-      '/opt/homebrew/bin/codex',
-      '/usr/local/bin/codex',
-      '/usr/bin/codex',
-      path.join(homeDir, '.npm-global', 'bin', 'codex'),
-      // Linuxbrew
-      '/home/linuxbrew/.linuxbrew/bin/codex',
-      // Volta
-      path.join(homeDir, '.volta', 'bin', 'codex'),
-      // pnpm global
-      path.join(homeDir, '.local', 'share', 'pnpm', 'codex'),
-      // Yarn global
-      path.join(homeDir, '.yarn', 'bin', 'codex'),
-      path.join(homeDir, '.config', 'yarn', 'global', 'node_modules', '.bin', 'codex'),
-      // Snap packages
-      '/snap/bin/codex',
-    ];
+    // Reuse the canonical path list from the detection service (incl. NVM/fnm
+    // dynamic paths) rather than maintaining a second, drift-prone copy.
+    return findCliCommandSync('codex', getCodexCliPaths(), logger);
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,12 @@ overrides:
   undici: '>=7.24.0'
   flatted: '>=3.4.2'
   tar@>=6: '>=7.5.11'
-  hono: '>=4.12.18 <5.0.0'
+  hono: '>=4.12.21 <5.0.0'
   fast-uri: '>=3.1.2 <4.0.0'
   jest: '>=30.3.0 <30.4.0'
   '@hono/node-server': '>=1.19.13'
   '@xmldom/xmldom': '>=0.8.12 <0.9.0'
-  axios: '>=1.15.0'
+  axios: '>=1.16.0'
   follow-redirects: '>=1.16.0'
   lodash: '>=4.18.0'
   handlebars: '>=4.7.9'
@@ -23,11 +23,14 @@ overrides:
   path-to-regexp@<1: '>=0.1.13 <0.2.0'
   picomatch: '>=4.0.4'
   file-type: '>=21.3.2'
-  brace-expansion@>=5: '>=5.0.5'
+  brace-expansion@>=5: '>=5.0.6'
   yaml@>=2: '>=2.8.3'
   '@tootallnate/once': '>=3.0.1'
   postcss: '>=8.5.10'
   ip-address: '>=10.1.1'
+  ws: '>=8.20.1 <9.0.0'
+  qs: '>=6.15.2'
+  tmp: '>=0.2.7'
 
 importers:
 
@@ -1331,7 +1334,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.18 <5.0.0'
+      hono: '>=4.12.21 <5.0.0'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -3193,8 +3196,8 @@ packages:
     resolution: {integrity: sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==}
     engines: {node: '>=10.12.0'}
 
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+  axios@1.17.0:
+    resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
 
   babel-jest@30.3.0:
     resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
@@ -3289,8 +3292,8 @@ packages:
   brace-expansion@2.0.3:
     resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -4464,8 +4467,8 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@4.1.0:
@@ -5830,12 +5833,8 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
-    engines: {node: '>=0.6'}
-
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quick-lru@5.1.1:
@@ -6460,8 +6459,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -6896,8 +6895,8 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7762,9 +7761,9 @@ snapshots:
     dependencies:
       '@hapi/hoek': 11.0.7
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.23
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -8213,7 +8212,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.23)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -8223,7 +8222,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.23
       jose: 6.2.0
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -10104,13 +10103,15 @@ snapshots:
 
   atomically@1.7.0: {}
 
-  axios@1.15.2:
+  axios@1.17.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   babel-jest@30.3.0(@babel/core@7.29.0):
     dependencies:
@@ -10228,7 +10229,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -10243,7 +10244,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -10261,7 +10262,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10888,7 +10889,7 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.18.3
+      ws: 8.21.0
       xmlhttprequest-ssl: 2.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -10907,7 +10908,7 @@ snapshots:
       cors: 2.8.6
       debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.18.3
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -11219,7 +11220,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -11254,7 +11255,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -11782,7 +11783,7 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  hono@4.12.18: {}
+  hono@4.12.23: {}
 
   hosted-git-info@4.1.0:
     dependencies:
@@ -13183,7 +13184,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -13598,11 +13599,7 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  qs@6.14.2:
-    dependencies:
-      side-channel: 1.1.0
-
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -14180,7 +14177,7 @@ snapshots:
   socket.io-adapter@2.5.6:
     dependencies:
       debug: 4.4.3
-      ws: 8.18.3
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -14471,9 +14468,9 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.5
+      tmp: 0.2.7
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   tmpl@1.0.5: {}
 
@@ -14835,13 +14832,14 @@ snapshots:
 
   wait-on@9.0.10:
     dependencies:
-      axios: 1.15.2
+      axios: 1.17.0
       joi: 18.2.1
       lodash: 4.18.1
       minimist: 1.2.8
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   walker@1.0.8:
     dependencies:
@@ -14914,7 +14912,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@8.18.3: {}
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
## Summary
- **CLI resolution & input boundaries:** single-source the Claude/Codex CLI install-path lists (fixes a "detected but won't launch" spawn failure when the CLI lives on an nvm/fnm-managed node), and validate MCP status/tasks HTTP payloads field-by-field before they drive session state.
- **Session concurrency & lifecycle:** per-repo worktree mutex, an in-flight launch counter that actually enforces `MAX_CONCURRENT_SESSIONS`, a guard so a stale MCP status can't resurrect a closed session, a null-guard on the async baseline-commit write, and an error response (instead of a hung Socket.io ack) when a launch throws.
- **Persistence durability:** back up the workspace store before `clearInvalidConfig` wipes it, persist provider enable/disable across restarts, and surface rejected `store:set` writes instead of silently dropping quick actions. Plus a git-diff perf fix (single `ls-files` vs. full status scan) and keyboard-accessible sidebar tabs.

## Test plan
- [ ] "Launch all" / rapid session creation stops at the cap (12) instead of over-spawning PTYs
- [ ] Disable a provider (e.g. Codex) in Settings → AI Capabilities, restart; confirm it stays disabled
- [ ] Open the git diff panel on a repo with untracked files; they still appear
- [ ] Keyboard-navigate sidebar project tabs (Tab to focus, Enter/Space to switch) without a mouse
- [ ] `pnpm typecheck` + `pnpm -r test` green

## Notes for reviewers
- Behavior change: a disabled provider now stays disabled across restarts (previously reset to `autoEnable`). New additive `plugin-host.json` store, no migration.
- IPC contract change: `store:set` now returns `{ ok, reason }` (was `void`); preload + renderer both updated.
- MCP status HTTP endpoint now returns 400 for malformed/stale payloads.
- No new env vars; no auth/payment/schema-migration changes.
- Pre-existing repo-wide `pnpm lint` failure lives in `apps/docs` generated build output (fails on `master` too, gitignored); in-scope code is lint-clean.

Produced by a production-mode `/audit` sweep; residual findings tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin enable/disable choices now persist across restarts.
  * Store write API now reports structured success/failure results to callers.

* **Bug Fixes**
  * Stronger session concurrency checks to prevent over-spawning.
  * Session status updates no longer revive finished/errored sessions.
  * Workspace store corruption is backed up before recovery; safer worktree/prepare serialization.
  * CLI detection and path handling improved.

* **Accessibility**
  * Keyboard activation for sidebar items; better button ARIA labels.

* **Tests**
  * Added regression tests for concurrency, validation, persistence, and untracked-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->